### PR TITLE
Add further ACE medical rewrite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Standalone Arma 3 Alternative Medical System
 -   ACE features support
 -   Own revive system (Only when ACE medical is not loaded)
 -   UI and QoL additions
--   ACE medical rewrite support (WIP)
+-   ACE medical rewrite support
 
-## Info
+## Info - Standalone mode
 
 The Armor Plates System is at its core a stand-alone medical system. It is meant to abstract Arma 3’s vanilla damage and streamline the vanilla medical system. It draws inspiration from COD MW Warzone’s medical system and allows you to put ceramic plates into your vest which act as additional HP.
 
@@ -25,8 +25,15 @@ Your unit’s HP and armor plates are shown beneath the stamina bar. Switching u
 
 This system makes heavy use of CBA settings, allowing server owners or mission makers to make players or AI as tanky or brittle as you’d like. If you are playing a mission that is incompatible with this system or uses its own medical system with it, you can simply disable the Armor Plates System, restart the mission, and play the mission without this mod interfering. However, ALL of the mod’s features will be disabled!
 
-## ACE Medical support
+## Info - ACE Medical mode
 
-Right now the support is rather minimal. The armor plates will stop incoming bullet damage, but it will not stop damage from car crashes, fall damage or from drowning. Most of this mod’s features are geared for the standalone use without ACE medical and are not available when ACE medical is loaded alongside this mod.
+When ACE with its medical components (rewrite and NOT old medical!) is loaded, APS will switch its standalone arcade mode to a more realistically one. In this mode the plates in your vest will only protect from gunshots and blunt force to your torso. If your limbs or your head gets hit, it will react as ACE medical normally would. There will not be any unit HP either, as this does not fit into the ACE medical system with its structural damage and blood simulation. Many of the standalone mode’s features will be disabled, some feedback features will be still available, but turned off by default.
 
-Steam workshop: https://steamcommunity.com/sharedfiles/filedetails/?edit=true&id=2523439183
+Ceramic plates now have a certain thickness (settable in addon options) which bullets can penetrate and bleed damage to the lower plates, or to your torso. Ceramic plates are also getting destroyed faster the less integrity (health) they have left, making it more likely that a gunshot will damage deeper protective layers.
+
+Overall, this will make units with ceramic plates in their vests more survivable, but only temporarily as the plates can be destroyed. Damage to units without any plates will behave the same as ACE medical. Going for the head will still work as before.
+
+## Links
+
+Steam workshop: https://steamcommunity.com/sharedfiles/filedetails/?edit=true&id=2523439183 \
+BI thread: https://forums.bohemia.net/forums/topic/235085-armor-plates-system-standalone-alternative-medical-system/

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -12,7 +12,7 @@ class CfgWeapons {
         descriptionShort = CSTRING(plateIteml_Desc_Short);
         descriptionUse = CSTRING(plateIteml_Desc_Use);
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 35;
+            mass = PLATE_MASS;
         };
     };
 };

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -1,26 +1,31 @@
-PREP(hitEh);
-PREP(handleDamageEh);
 PREP(initPlates);
-PREP(receiveDamage);
 PREP(updatePlateUi);
 PREP(updateHPUi);
-PREP(handleHealEh);
-PREP(hasHealItems);
-PREP(addPlayerHoldActions);
-PREP(getHitpointArmor);
-PREP(getItemArmor);
-PREP(startHpRegen);
 PREP(canAddPlate);
 PREP(addPlate);
 PREP(canPressKey);
 PREP(showDamageFeedbackMarker);
-PREP(setUnconscious);
-PREP(handleDamageEhACE);
 PREP(initAIUnit);
-PREP(setA3Damage);
-PREP(showDownedSkull);
-PREP(addActionsToUnit);
 PREP(createProgressBar);
 PREP(deleteProgressBar);
-PREP(drawDownedUnitIndicator);
-PREP(canRevive);
+
+if (GVAR(aceMedicalLoaded)) then {
+    PREP(handleDamageEhACE);
+    PREP(receiveDamageACE);
+} else {
+    PREP(hitEh);
+    PREP(handleDamageEh);
+    PREP(handleHealEh);
+    PREP(receiveDamage);
+    PREP(hasHealItems);
+    PREP(addPlayerHoldActions);
+    PREP(getHitpointArmor);
+    PREP(getItemArmor);
+    PREP(startHpRegen);
+    PREP(drawDownedUnitIndicator);
+    PREP(canRevive);
+    PREP(setA3Damage);
+    PREP(showDownedSkull);
+    PREP(addActionsToUnit);
+    PREP(setUnconscious);
+};

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -235,7 +235,9 @@ if !(GVAR(aceMedicalLoaded)) then {
         for "_i" from 1 to GVAR(numWearablePlates) do {
             _plates pushBack GVAR(maxPlateHealth);
         };
-        (vestContainer player) setVariable [QGVAR(plates), _plates];
+        private _vest = vestContainer player;
+        _vest setVariable [QGVAR(plates), _plates];
+        _vest setVariable ["ace_movement_vLoad", (_vest getVariable ["ace_movement_vLoad", 0]) + (PLATE_MASS * GVAR(numWearablePlates)), true];
     };
     [] call FUNC(initPlates);
     player setVariable [QGVAR(vestContainer), vestContainer player];

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -26,7 +26,6 @@ if (hasInterface) then {
     uiNamespace setVariable [QGVAR(skullControls), []];
 };
 
-GVAR(aceMedicalLoaded) = isClass(configFile >> "CfgPatches" >> "ace_medical_engine");
 if (isClass(configFile >> "CfgPatches" >> "ace_medical") && {!GVAR(aceMedicalLoaded)}) exitWith {
     INFO("PostInit: Disabled --> old ACE medical loaded");
 };

--- a/addons/main/XEH_preInit.sqf
+++ b/addons/main/XEH_preInit.sqf
@@ -1,14 +1,18 @@
 #include "script_component.hpp"
 ADDON = false;
 
-if (isClass(configFile >> "CfgPatches" >> "ace_medical") && {!isClass(configFile >> "CfgPatches" >> "ace_medical_engine")}) exitWith {
+GVAR(aceMedicalLoaded) = isClass(configFile >> "CfgPatches" >> "ace_medical_engine");
+if (isClass(configFile >> "CfgPatches" >> "ace_medical") && {!GVAR(aceMedicalLoaded)}) exitWith {
     INFO("PreInit: Disabled --> old ACE medical loaded");
 };
 
 #include "XEH_PREP.hpp"
+if (GVAR(aceMedicalLoaded)) then {
+    #include "initSettingsACE.sqf"
+} else {
+    #include "initSettings.sqf"
 
-#include "initSettings.sqf"
-
-GVAR(armorCache) = false call CBA_fnc_createNamespace;
+    GVAR(armorCache) = false call CBA_fnc_createNamespace;
+};
 
 ADDON = true;

--- a/addons/main/functions/fnc_addPlate.sqf
+++ b/addons/main/functions/fnc_addPlate.sqf
@@ -28,19 +28,25 @@ _player forceWalk true;
         !([_player] call FUNC(canAddPlate))
         }}}) exitWith {};
 
-    private _plates = (vestContainer _player) getVariable [QGVAR(plates), []];
+    private _vest = vestContainer _player;
+    private _plates = _vest getVariable [QGVAR(plates), []];
+    private _vLoad = _vest getVariable ["ace_movement_vLoad", 0];
 
     if (_plates isNotEqualTo []) then {
         // get last plate, it might be already damaged
         private _count = count _plates;
+        _plates sort false;
         private _lastPlate = _plates deleteAt (_count - 1);
         _plates pushBack GVAR(maxPlateHealth);
         if (_count < GVAR(numWearablePlates)) then {
             // add the last plate back
             _plates pushBack _lastPlate;
+            _vest setVariable ["ace_movement_vLoad", _vLoad + PLATE_MASS, true];
         };
+        _plates sort false;
     } else {
         _plates pushBack GVAR(maxPlateHealth);
+        _vest setVariable ["ace_movement_vLoad", _vLoad + PLATE_MASS, true];
     };
     _player removeItem QGVAR(plate);
     (vestContainer _player) setVariable [QGVAR(plates), _plates];

--- a/addons/main/functions/fnc_handleDamageEhACE.sqf
+++ b/addons/main/functions/fnc_handleDamageEhACE.sqf
@@ -8,7 +8,7 @@
 #define PRIORITY_LEFT_LEG   (1 + random 1)
 #define PRIORITY_RIGHT_LEG  (1 + random 1)
 
-params ["_unit", "_selection", "_damage", "_shooter", "_ammo", "_hitPointIndex", "_instigator", "_hitpoint"];
+params ["_unit", "", "_damage", "_shooter", "_ammo", "_hitPointIndex", "_instigator", "_hitpoint"];
 if !(local _unit) exitWith {nil};
 
 private _curDamage = 0;

--- a/addons/main/functions/fnc_handleDamageEhACE.sqf
+++ b/addons/main/functions/fnc_handleDamageEhACE.sqf
@@ -1,5 +1,14 @@
 #include "script_component.hpp"
-params ["_unit", "", "_damage", "_source", "_projectile", "_hitIndex", "_instigator", "_hitPoint"];
+#include "\z\ace\addons\medical_engine\script_macros_medical.hpp"
+
+#define PRIORITY_HEAD       3
+#define PRIORITY_BODY       4
+#define PRIORITY_LEFT_ARM   (1 + random 1)
+#define PRIORITY_RIGHT_ARM  (1 + random 1)
+#define PRIORITY_LEFT_LEG   (1 + random 1)
+#define PRIORITY_RIGHT_LEG  (1 + random 1)
+
+params ["_unit", "_selection", "_damage", "_shooter", "_ammo", "_hitPointIndex", "_instigator", "_hitpoint"];
 if !(local _unit) exitWith {nil};
 
 private _curDamage = 0;
@@ -7,7 +16,7 @@ if (_hitPoint isEqualTo "") then {
     _hitPoint = "#structural";
     _curDamage = damage _unit;
 } else {
-    _curDamage = _unit getHitIndex _hitIndex;
+    _curDamage = _unit getHitIndex _hitPointIndex;
 };
 
 if (!isDamageAllowed _unit || {_hitPoint in ["hithead", "hitbody", "hithands", "hitlegs"] || {_unit getVariable ["ace_medical_allowDamage", false]}}) exitWith {_curDamage};
@@ -17,6 +26,116 @@ if (_newDamage isEqualTo 0) exitWith {
     _curDamage
 };
 
+private _armor = [_unit, _hitpoint] call ace_medical_engine_fnc_getHitpointArmor;
+private _realDamage = _newDamage * _armor;
+_unit setVariable [format ["ace_medical_engine_$%1", _hitPoint], [_realDamage, _newDamage]];
+
+if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
+    if (_ammo isEqualTo "") exitWith {
+        // let ace do the thing
+        _this call ace_medical_engine_fnc_handleDamage;
+        0;
+    };
+
+    // write hitpoint damage to unit var
+
+    private _damageStructural = _unit getVariable ["ace_medical_engine_$#structural", 0];
+
+    // --- Head
+    private _damageHead = [
+        _unit getVariable ["ace_medical_engine_$HitFace", [0,0]],
+        _unit getVariable ["ace_medical_engine_$HitNeck", [0,0]],
+        _unit getVariable ["ace_medical_engine_$HitHead", [0,0]]
+    ];
+    _damageHead sort false;
+    _damageHead = _damageHead select 0;
+
+    // --- Body
+    private _damageBody = [
+        _unit getVariable ["ace_medical_engine_$HitPelvis", [0,0]],
+        _unit getVariable ["ace_medical_engine_$HitAbdomen", [0,0]],
+        _unit getVariable ["ace_medical_engine_$HitDiaphragm", [0,0]],
+        _unit getVariable ["ace_medical_engine_$HitChest", [0,0]]
+        // HitBody removed as it's a placeholder hitpoint and the high armor value (1000) throws the calculations off
+    ];
+    _damageBody sort false;
+    _damageBody = _damageBody select 0;
+
+    // --- Arms and Legs
+    private _damageLeftArm = _unit getVariable ["ace_medical_engine_$HitLeftArm", [0,0]];
+    private _damageRightArm = _unit getVariable ["ace_medical_engine_$HitRightArm", [0,0]];
+    private _damageLeftLeg = _unit getVariable ["ace_medical_engine_$HitLeftLeg", [0,0]];
+    private _damageRightLeg = _unit getVariable ["ace_medical_engine_$HitRightLeg", [0,0]];
+
+    // Find hit point that received the maxium damage
+    // Priority used for sorting if incoming damage is equivalent (e.g. max which is 4)
+    private _allDamages = [
+        _damageHead     + [PRIORITY_HEAD,      "Head"],
+        _damageBody     + [PRIORITY_BODY,      "Body"],
+        _damageLeftArm  + [PRIORITY_LEFT_ARM,  "LeftArm"],
+        _damageRightArm + [PRIORITY_RIGHT_ARM, "RightArm"],
+        _damageLeftLeg  + [PRIORITY_LEFT_LEG,  "LeftLeg"],
+        _damageRightLeg + [PRIORITY_RIGHT_LEG, "RightLeg"]
+    ];
+
+    // represents all incoming damage for selecting a non-selectionSpecific wound location, (used for selectRandomWeighted [value1,weight1,value2....])
+    private _damageSelectionArray = [
+        HITPOINT_INDEX_HEAD, _damageHead select 1, HITPOINT_INDEX_BODY, _damageBody select 1, HITPOINT_INDEX_LARM, _damageLeftArm select 1,
+        HITPOINT_INDEX_RARM, _damageRightArm select 1, HITPOINT_INDEX_LLEG, _damageLeftLeg select 1, HITPOINT_INDEX_RLEG, _damageRightLeg select 1
+    ];
+
+    _allDamages sort false;
+    (_allDamages select 0) params ["", "_receivedDamage", "", "_woundedHitPoint"];
+    private _receivedDamageHead = _damageHead select 1;
+    if (_receivedDamageHead >= HEAD_DAMAGE_THRESHOLD) then {
+        _receivedDamage = _receivedDamageHead;
+        _woundedHitPoint = "Head";
+    };
+
+    // We know it's structural when no specific hitpoint is damaged
+    if (_receivedDamage == 0) then {
+        _receivedDamage = _damageStructural select 1;
+        _woundedHitPoint = "Body";
+        _damageSelectionArray = [1, 1]; // sum of weights would be 0
+    };
+
+    if (_woundedHitPoint isNotEqualTo "Body") exitWith {
+        // let ace do the thing
+        _unit setVariable [format ["ace_medical_engine_$%1", _hitPoint], nil];
+        _this call ace_medical_engine_fnc_handleDamage;
+        0
+    };
+
+     // No wounds for minor damage
+    if (_receivedDamage > 1E-3) then {
+        // APS code begin
+
+        private _damageLeft = [_unit, _receivedDamage, _woundedHitPoint, [_instigator, _shooter] select (isNull _instigator), _ammo] call FUNC(receiveDamageACE);
+        // private _bodyArmor = [player, "HitBody"] call ace_medical_engine_fnc_getHitpointArmor;
+        // _damageLeft = _damageLeft / _bodyArmor;
+
+        _unit setVariable ["ace_medical_engine_$HitBody", [_realDamage, _newDamage]];
+
+        systemChat format ["D %1 | L %2 | %3", _receivedDamage, _damageLeft, _damageSelectionArray];
+
+        // APS code end
+
+        // ["ace_medical_woundReceived", [_unit, _woundedHitPoint, _damageLeft, _shooter, _ammo, _damageSelectionArray]] call CBA_fnc_localEvent;
+    };
+
+    // Clear stored damages otherwise they will influence future damage events
+    // (aka wounds will pile onto the historically most damaged hitpoint)
+    {
+        _unit setVariable [_x, nil];
+    } forEach [
+        "ace_medical_engine_$HitFace","ace_medical_engine_$HitNeck","ace_medical_engine_$HitHead",
+        "ace_medical_engine_$HitPelvis","ace_medical_engine_$HitAbdomen","ace_medical_engine_$HitDiaphragm","ace_medical_engine_$HitChest","ace_medical_engine_$HitBody",
+        "ace_medical_engine_$HitLeftArm","ace_medical_engine_$HitRightArm","ace_medical_engine_$HitLeftLeg","ace_medical_engine_$HitRightLeg"
+    ];
+
+    0
+};
+
 // Drowning doesn't fire the EH for each hitpoint
 // Damage occurs in consistent increments
 if (
@@ -24,6 +143,7 @@ if (
     {getOxygenRemaining _unit <= 0.5} &&
     {_damage isEqualTo (_curDamage + 0.005)}
 ) exitWith {
+    // let ace do the thing
     _this call ace_medical_engine_fnc_handleDamage;
     0
 };
@@ -33,28 +153,13 @@ if (
 private _vehicle = vehicle _unit;
 if (
     _hitPoint isEqualTo "#structural" &&
-    {_projectile isEqualTo ""} &&
+    {_ammo isEqualTo ""} &&
     {_vehicle != _unit} &&
     {vectorMagnitude (velocity _vehicle) > 5}
 ) exitWith {
+    // let ace do the thing
     _this call ace_medical_engine_fnc_handleDamage;
     0
-};
-
-// handle rest of damage
-private _armor = [_unit, _hitpoint] call ace_medical_engine_fnc_getHitpointArmor;
-private _mod = 1 + _armor/100;
-private _realDamage = _newDamage * _mod;
-_hitPoint = [_hitPoint, "hit", ""] call CBA_fnc_replace;
-
-private _var = format ["GVAR(lastHandleDamage)$%1", _hitPoint];
-if ((_unit getVariable [_var, -1]) isEqualTo _realDamage) exitWith {_curDamage};
-_unit setVariable [_var, _realDamage];
-private _damageLeft = [_unit, _realDamage, _hitPoint, [_instigator, _source] select (isNull _instigator)] call FUNC(receiveDamage);
-
-if (_damageLeft > 0) then {
-    _this set [2, _curDamage + (_damageLeft / _mod)];
-    _this call ace_medical_engine_fnc_handleDamage;
 };
 
 0

--- a/addons/main/functions/fnc_handleDamageEhACE.sqf
+++ b/addons/main/functions/fnc_handleDamageEhACE.sqf
@@ -143,10 +143,6 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
 
         private _damageLeft = [_unit, _receivedDamage, _actualDamage, [_instigator, _shooter] select (isNull _instigator), _ammo] call FUNC(receiveDamageACE);
 
-        if (_damageLeft > 0) then {
-            systemChat format ["D %1 | L %2 | %3", _receivedDamage, _damageLeft, _bodyArmor];
-        };
-
         // APS code end
 
         ["ace_medical_woundReceived", [_unit, _woundedHitPoint, _damageLeft, _shooter, _ammo, _damageSelectionArray]] call CBA_fnc_localEvent;

--- a/addons/main/functions/fnc_receiveDamage.sqf
+++ b/addons/main/functions/fnc_receiveDamage.sqf
@@ -1,16 +1,16 @@
 #include "script_component.hpp"
 params ["_unit", "_damage", "_bodyPart", "_instigator"];
-if (_damage <= 0 || {!alive _unit}) exitWith {0};
+if (_damage <= 0 || {!alive _unit}) exitWith {};
 
 private _maxHp = [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit);
 private _curHp = _unit getVariable [QGVAR(hp), _maxHp];
 
-if (_curHp <= 0) exitWith {-1};
+if (_curHp <= 0) exitWith {};
 
 if (GVAR(disallowFriendfire) &&
     {!isNull _instigator && {
     _instigator isNotEqualTo _unit && {
-    (side group _unit) isEqualTo (side group _instigator)}}}) exitWith {-1};
+    (side group _unit) isEqualTo (side group _instigator)}}}) exitWith {};
 
 private _isHeadshot = false;
 private _isTorso = false;
@@ -82,7 +82,7 @@ if (GVAR(audioFeedback) > 0 && {_player isEqualTo _unit}) then {
 };
 
 // no need to update unit health if there is no damage left
-if (_damage isEqualTo 0) exitWith {_damage};
+if (_damage isEqualTo 0) exitWith {};
 
 private _newHP = (_curHp - _damage) max 0;
 _unit setVariable [QGVAR(hp), [_newHP, 100] select GVAR(aceMedicalLoaded)];
@@ -92,8 +92,6 @@ if (_player isEqualTo _unit) then {
         [_unit, _instigator, _damage] call FUNC(showDamageFeedbackMarker);
     };
 };
-
-if (GVAR(aceMedicalLoaded)) exitWith {_damage / GVAR(damageCoef)};
 
 if (_newHP isEqualTo 0) exitWith {
     [QGVAR(downedMessage), [_unit], (units _unit) - [_unit]] call CBA_fnc_targetEvent;

--- a/addons/main/functions/fnc_receiveDamage.sqf
+++ b/addons/main/functions/fnc_receiveDamage.sqf
@@ -35,7 +35,8 @@ _damage = _damage * GVAR(damageCoef);
 
 private _player = call CBA_fnc_currentUnit;
 private _receivedDamage = false;
-private _plates = (vestContainer _unit) getVariable [QGVAR(plates), []];
+private _vest = vestContainer _unit;
+private _plates = _vest getVariable [QGVAR(plates), []];
 if (_plates isNotEqualTo []) then {
     // exit out and let rest of function handle the remaining damage
     // if torso was not hit and plates are set to only protect the torso
@@ -52,6 +53,7 @@ if (_plates isNotEqualTo []) then {
             // the plate shattered bleeding damage into lower plates
             _damage = abs _newDamage;
             _plates deleteAt _i;
+            _vest setVariable ["ace_movement_vLoad", 0 max ((_vest getVariable ["ace_movement_vLoad", 0]) - PLATE_MASS), true];
 
             if (_player isEqualTo _unit && {GVAR(audioFeedback) > 0 && {GVAR(lastPlateBreakSound) isNotEqualTo diag_frameNo}}) then {
                 GVAR(lastPlateBreakSound) = diag_frameNo;

--- a/addons/main/functions/fnc_receiveDamageACE.sqf
+++ b/addons/main/functions/fnc_receiveDamageACE.sqf
@@ -1,0 +1,64 @@
+#include "script_component.hpp"
+params ["_unit", "_damage", "_bodyPart", "_instigator", "_ammo"];
+if (_damage <= 0 || {!alive _unit}) exitWith {0};
+
+if (GVAR(disallowFriendfire) &&
+    {!isNull _instigator && {
+    _instigator isNotEqualTo _unit && {
+    (side group _unit) isEqualTo (side group _instigator)}}}) exitWith {-1};
+
+// if !(isMultiplayer) then {
+//     systemChat format ["%1 DMG: %2 form %5 --> %3 | %4", name _unit, _damage, _bodyPart, diag_frameNo, name _instigator];
+// };
+
+private _caliber = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_Caliber");
+private _mass = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_bulletMass");
+systemChat str _mmPenned;
+
+private _player = call CBA_fnc_currentUnit;
+private _receivedDamage = false;
+private _plates = (vestContainer _unit) getVariable [QGVAR(plates), []];
+if (_bodyPart isEqualTo "Body" && {_plates isNotEqualTo []}) then {
+    for "_i" from ((count _plates) - 1) to 0 step -1 do {
+        private _plateIntegrity = _plates select _i;
+        private _newDamage = _plateIntegrity - _damage;
+        private _pennDamage = 0;
+        private _mmPenned = _damage * _caliber * _mass / GVAR(plateThickness);
+        if (_mmPenned > 1) then {
+            // plate was penetrated!
+            _pennDamage = _damage * ((_mmPenned - 1) min 0.5);
+            systemChat format ["PENNED! %1 | %2", _mmPenned, _pennDamage];
+        };
+        if (_newDamage > 0) then {
+            // plate managed to soak the damage
+            _plates set [_i, _newDamage];
+            _damage = _pennDamage;
+        } else {
+            // the plate shattered
+            _damage = (abs _newDamage) + _pennDamage;
+            _plates deleteAt _i;
+
+            if (_player isEqualTo _unit && {GVAR(audioFeedback) > 0 && {GVAR(lastPlateBreakSound) isNotEqualTo diag_frameNo}}) then {
+                GVAR(lastPlateBreakSound) = diag_frameNo;
+                playsound format [QGVAR(platebreak%1_%2), 1 + floor random 3, GVAR(audioFeedback)];
+            };
+        };
+    };
+    _unit setVariable [QGVAR(plates), _plates];
+    if (_player isEqualTo _unit) then {
+        [_unit] call FUNC(updatePlateUi);
+        if (GVAR(showDamageMarker)) then {
+            [_unit, _instigator, _damage] call FUNC(showDamageFeedbackMarker);
+        };
+        _receivedDamage = true;
+    };
+};
+
+if (GVAR(audioFeedback) > 0 && {_player isEqualTo _unit}) then {
+    if (GVAR(lastHPDamageSound) isNotEqualTo diag_frameNo) then {
+        GVAR(lastHPDamageSound) = diag_frameNo;
+        playsound format [QGVAR(hit%1_%2), 1 + floor random 3, GVAR(audioFeedback)];
+    };
+};
+
+_damage

--- a/addons/main/functions/fnc_receiveDamageACE.sqf
+++ b/addons/main/functions/fnc_receiveDamageACE.sqf
@@ -4,7 +4,8 @@ if (_damage <= 0 || {!alive _unit}) exitWith {0};
 
 private _initialActualDamage = _actualDamage;
 private _player = call CBA_fnc_currentUnit;
-private _plates = (vestContainer _unit) getVariable [QGVAR(plates), []];
+private _vest = vestContainer _unit;
+private _plates = _vest getVariable [QGVAR(plates), []];
 if (_plates isNotEqualTo []) then {
     private _caliber = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_Caliber");
     private _mass = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_bulletMass");
@@ -25,6 +26,7 @@ if (_plates isNotEqualTo []) then {
             // the plate shattered
             _actualDamage = (abs _newDamage) + _pennDamage;
             _plates deleteAt _i;
+            _vest setVariable ["ace_movement_vLoad", 0 max ((_vest getVariable ["ace_movement_vLoad", 0]) - PLATE_MASS), true];
 
             if (_player isEqualTo _unit && {GVAR(audioFeedback) > 0 && {GVAR(lastPlateBreakSound) isNotEqualTo diag_frameNo}}) then {
                 GVAR(lastPlateBreakSound) = diag_frameNo;

--- a/addons/main/functions/fnc_showDamageFeedbackMarker.sqf
+++ b/addons/main/functions/fnc_showDamageFeedbackMarker.sqf
@@ -39,7 +39,7 @@ uiNamespace setVariable [QGVAR(feedBackCtrl), _feedback];
 },{
     params ["_ctrl"];
     _ctrl ctrlSetFade 1;
-    _ctrl ctrlSetPosition [-0.2, -0.2, 1.2, 1.2];
+    _ctrl ctrlSetPosition [-0.2, -0.2, 1.4, 1.4];
     _ctrl ctrlCommit 5;
     [{
         (_this select 0) ctrlSetAngle [180 + ([_this select 1, _this select 2] call BIS_fnc_dirTo) - ((positionCameratoWorld [0,0,0] vectorFromTo (positionCameraToWorld [0,0,1])) call CBA_fnc_vectDir), 0.5, 0.5, true];

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -1,6 +1,5 @@
 private _header = LLSTRING(category);
 private _category = [_header, LLSTRING(subCategoryArmorPlates)];
-private _aceMedicalLoaded = isClass(configFile >> "CfgPatches" >> "ace_medical_engine");
 
 [
     QGVAR(numWearablePlates),
@@ -153,65 +152,60 @@ _category = [_header, LLSTRING(subCategoryFeedback)];
     false
 ] call CBA_fnc_addSetting;
 
-if (_aceMedicalLoaded) then {
-    GVAR(showDownedSkull) = false;
-    GVAR(showDownedUnitIndicator) = false;
-} else {
-    [
-        QGVAR(showDownedSkull),
-        "CHECKBOX",
-        [LLSTRING(showDownedSkull), LLSTRING(showDownedSkull_desc)],
-        _category,
-        true,
-        false
-    ] call CBA_fnc_addSetting;
+[
+    QGVAR(showDownedSkull),
+    "CHECKBOX",
+    [LLSTRING(showDownedSkull), LLSTRING(showDownedSkull_desc)],
+    _category,
+    true,
+    false
+] call CBA_fnc_addSetting;
 
-    [
-        QGVAR(showDownedUnitIndicator),
-        "CHECKBOX",
-        [LLSTRING(showDownedUnitIndicator), LLSTRING(showDownedUnitIndicator_desc)],
-        _category,
-        true,
-        false, {
-            params ["_value"];
-            if (time < 1) exitWith {};
-            if (_value) then {
-                if (GVAR(downedUnitIndicatorDrawEh) < 0) then {
-                    GVAR(downedUnitIndicatorDrawEh) = addMissionEventHandler ["Draw3D", {
-                        call FUNC(drawDownedUnitIndicator);
-                    }];
-                };
-            } else {
-                if (GVAR(downedUnitIndicatorDrawEh) >= 0) then {
-                    removeMissionEventHandler ["Draw3D", GVAR(downedUnitIndicatorDrawEh)];
-                    GVAR(downedUnitIndicatorDrawEh) = -1;
-                };
-            }
+[
+    QGVAR(showDownedUnitIndicator),
+    "CHECKBOX",
+    [LLSTRING(showDownedUnitIndicator), LLSTRING(showDownedUnitIndicator_desc)],
+    _category,
+    true,
+    false, {
+        params ["_value"];
+        if (time < 1) exitWith {};
+        if (_value) then {
+            if (GVAR(downedUnitIndicatorDrawEh) < 0) then {
+                GVAR(downedUnitIndicatorDrawEh) = addMissionEventHandler ["Draw3D", {
+                    call FUNC(drawDownedUnitIndicator);
+                }];
+            };
+        } else {
+            if (GVAR(downedUnitIndicatorDrawEh) >= 0) then {
+                removeMissionEventHandler ["Draw3D", GVAR(downedUnitIndicatorDrawEh)];
+                GVAR(downedUnitIndicatorDrawEh) = -1;
+            };
         }
-    ] call CBA_fnc_addSetting;
+    }
+] call CBA_fnc_addSetting;
 
-    [
-        QGVAR(showDownedUnitIndicatorRange),
-        "SLIDER",
-        [LLSTRING(showDownedUnitIndicatorRange), LLSTRING(showDownedUnitIndicatorRange_desc)],
-        _category,
-        [0, 500, 100, 0],
-        false,
-        {
-            params ["_value"];
-            GVAR(showDownedUnitIndicatorRange) = round _value;
-        }
-    ] call CBA_fnc_addSetting;
+[
+    QGVAR(showDownedUnitIndicatorRange),
+    "SLIDER",
+    [LLSTRING(showDownedUnitIndicatorRange), LLSTRING(showDownedUnitIndicatorRange_desc)],
+    _category,
+    [0, 500, 100, 0],
+    false,
+    {
+        params ["_value"];
+        GVAR(showDownedUnitIndicatorRange) = round _value;
+    }
+] call CBA_fnc_addSetting;
 
-    [
-        QGVAR(showDownedUnitIndicatorSize),
-        "SLIDER",
-        [LLSTRING(showDownedUnitIndicatorSize), LLSTRING(showDownedUnitIndicatorSize_desc)],
-        _category,
-        [0, 10, 2, 2],
-        false
-    ] call CBA_fnc_addSetting;
-};
+[
+    QGVAR(showDownedUnitIndicatorSize),
+    "SLIDER",
+    [LLSTRING(showDownedUnitIndicatorSize), LLSTRING(showDownedUnitIndicatorSize_desc)],
+    _category,
+    [0, 10, 2, 2],
+    false
+] call CBA_fnc_addSetting;
 
 _category = [_header, LLSTRING(subCategoryGeneral)];
 
@@ -231,7 +225,7 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
     "SLIDER",
     [LLSTRING(damageCoef), LLSTRING(damageCoef_desc)],
     _category,
-    [0.01, 100, [50, 5] select _aceMedicalLoaded, 2],
+    [0.01, 100, 50, 2],
     true
 ] call CBA_fnc_addSetting;
 
@@ -261,8 +255,6 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
     false,
     true
 ] call CBA_fnc_addSetting;
-
-if (_aceMedicalLoaded) exitWith {};
 
 [
     QGVAR(damageEhVariant),

--- a/addons/main/initSettingsACE.sqf
+++ b/addons/main/initSettingsACE.sqf
@@ -1,0 +1,179 @@
+private _header = LLSTRING(category);
+private _category = [_header, LLSTRING(subCategoryArmorPlates)];
+
+[
+    QGVAR(numWearablePlates),
+    "SLIDER",
+    [LLSTRING(numWearablePlates), LLSTRING(numWearablePlates_desc)],
+    _category,
+    [0, 10, 3, 0],
+    true,
+    {
+        params ["_value"];
+        GVAR(numWearablePlates) = round _value;
+        if (time < 1) exitWith {};
+        {
+            ctrlDelete (_x select 0);
+            ctrlDelete (_x select 1);
+        } forEach (uiNamespace getVariable [QGVAR(plateControls), []]);
+        uiNamespace setVariable [QGVAR(plateControls), []];
+        [] call FUNC(initPlates);
+    }
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateThickness),
+    "SLIDER",
+    [LLSTRING(plateThickness), LLSTRING(plateThickness_desc)],
+    _category,
+    [0, 50, 25, 0],
+    true,
+    {
+        params ["_value"];
+        GVAR(plateThickness) = round _value;
+    }
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(maxPlateHealth),
+    "SLIDER",
+    [LLSTRING(maxPlateHealth), LLSTRING(maxPlateHealth_desc)],
+    _category,
+    [1, 15, 1, 0],
+    true,
+    {
+        params ["_value"];
+        GVAR(maxPlateHealth) = round _value;
+    }
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(timeToAddPlate),
+    "SLIDER",
+    [LLSTRING(timeToAddPlate), LLSTRING(timeToAddPlate_desc)],
+    _category,
+    [0, 30, 8, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(allowPlateReplace),
+    "CHECKBOX",
+    [LLSTRING(allowPlateReplace), LLSTRING(allowPlateReplace_desc)],
+    _category,
+    true,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(protectOnlyTorso),
+    "CHECKBOX",
+    [LLSTRING(protectOnlyTorso), LLSTRING(protectOnlyTorso_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(spawnWithFullPlates),
+    "CHECKBOX",
+    [LLSTRING(spawnWithFullPlates), LLSTRING(spawnWithFullPlates_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AIchancePlateInVest),
+    "SLIDER",
+    [LLSTRING(AIchancePlateInVest), LLSTRING(AIchancePlateInVest_desc)],
+    _category,
+    [0, 1, 0.4, 0, true],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AIchancePlateInVestMaxNo),
+    "SLIDER",
+    [LLSTRING(AIchancePlateInVestMaxNo), LLSTRING(AIchancePlateInVestMaxNo_desc)],
+    _category,
+    [0, 10, 0, 0],
+    true,
+    {
+        params ["_value"];
+        GVAR(AIchancePlateInVestMaxNo) = round _value;
+    }
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AIchancePlateInInventory),
+    "SLIDER",
+    [LLSTRING(AIchancePlateInInventory), LLSTRING(AIchancePlateInInventory_desc)],
+    _category,
+    [0, 1, 0.2, 0, true],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AIchancePlateInInventoryMaxNo),
+    "SLIDER",
+    [LLSTRING(AIchancePlateInInventoryMaxNo), LLSTRING(AIchancePlateInInventoryMaxNo_desc)],
+    _category,
+    [0, 10, 0, 0],
+    true,
+    {
+        params ["_value"];
+        GVAR(AIchancePlateInInventoryMaxNo) = round _value;
+    }
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateColor),
+    "COLOR",
+    LLSTRING(plateColor),
+    _category,
+    [0.35, 0.35, 1, 0.8],
+    false
+] call CBA_fnc_addSetting;
+
+_category = [_header, LLSTRING(subCategoryFeedback)];
+
+[
+    QGVAR(showDamageMarker),
+    "CHECKBOX",
+    [LLSTRING(showDamageMarker), LLSTRING(showDamageMarker_desc)],
+    _category,
+    true,
+    false
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(audioFeedback),
+    "LIST",
+    [LLSTRING(audioFeedback), LLSTRING(audioFeedback_desc)],
+    _category,
+    [[0, 1, 2, 3, 4], [LLSTRING(downedFeedback_0), LLSTRING(audioFeedback_1), LLSTRING(audioFeedback_2), LLSTRING(audioFeedback_3), LLSTRING(audioFeedback_4)], 3],
+    false
+] call CBA_fnc_addSetting;
+
+_category = [_header, LLSTRING(subCategoryGeneral)];
+
+[
+    QGVAR(enable),
+    "CHECKBOX",
+    [LLSTRING(enable), LLSTRING(enable_desc)],
+    _category,
+    true,
+    true,
+    {},
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(disallowFriendfire),
+    "CHECKBOX",
+    [LLSTRING(disallowFriendfire), LLSTRING(disallowFriendfire_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;

--- a/addons/main/initSettingsACE.sqf
+++ b/addons/main/initSettingsACE.sqf
@@ -39,7 +39,7 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     "SLIDER",
     [LLSTRING(maxPlateHealth), LLSTRING(maxPlateHealth_desc)],
     _category,
-    [1, 15, 1, 0],
+    [1, 50, 15, 0],
     true,
     {
         params ["_value"];
@@ -62,15 +62,6 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     [LLSTRING(allowPlateReplace), LLSTRING(allowPlateReplace_desc)],
     _category,
     true,
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(protectOnlyTorso),
-    "CHECKBOX",
-    [LLSTRING(protectOnlyTorso), LLSTRING(protectOnlyTorso_desc)],
-    _category,
-    false,
     true
 ] call CBA_fnc_addSetting;
 
@@ -143,7 +134,7 @@ _category = [_header, LLSTRING(subCategoryFeedback)];
     "CHECKBOX",
     [LLSTRING(showDamageMarker), LLSTRING(showDamageMarker_desc)],
     _category,
-    true,
+    false,
     false
 ] call CBA_fnc_addSetting;
 
@@ -152,7 +143,7 @@ _category = [_header, LLSTRING(subCategoryFeedback)];
     "LIST",
     [LLSTRING(audioFeedback), LLSTRING(audioFeedback_desc)],
     _category,
-    [[0, 1, 2, 3, 4], [LLSTRING(downedFeedback_0), LLSTRING(audioFeedback_1), LLSTRING(audioFeedback_2), LLSTRING(audioFeedback_3), LLSTRING(audioFeedback_4)], 3],
+    [[0, 1, 2, 3, 4], [LLSTRING(downedFeedback_0), LLSTRING(audioFeedback_1), LLSTRING(audioFeedback_2), LLSTRING(audioFeedback_3), LLSTRING(audioFeedback_4)], 0],
     false
 ] call CBA_fnc_addSetting;
 

--- a/addons/main/script_component.hpp
+++ b/addons/main/script_component.hpp
@@ -16,3 +16,4 @@
 
 #define TYPE_UNIFORM 801
 #define HEIGHTMOD_HPBARS 0.5
+#define PLATE_MASS 35

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -283,5 +283,11 @@
         <Key ID="STR_diw_armor_plates_main_reviveUnit">
             <English>Reviving %1, keep holding the button!</English>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_plateThickness">
+            <English>Thickness</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateThickness_desc">
+            <English>Sets the thickness of each plate. The thicker it is the less likely it is for a bullet to penetrate it before its integrety has reached 0</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
- Only compile functions that are needed when ace is loaded
- Rework HandleDamage, use ace_hdbracket correctly
- handle plate integrety
- account for bullets penetrating one plate and going further down to the next

- [x] figure out damage before armor
- [x] Adapt handledamage eh
- [x] split cba settings for ace and standalone usage
- [x] make damage bleed down to next plate if penetrated
- [x] Add missing string table entries
- [x] fix adding plates when multiple plates are damaged
- [x] Test standalone mode