### PR TITLE
Add filter damage for HandleDamage eh

### DIFF
--- a/addons/main/functions/fnc_handleDamageEh.sqf
+++ b/addons/main/functions/fnc_handleDamageEh.sqf
@@ -11,7 +11,7 @@ if (_hitPoint isEqualTo "") then {
     _curDamage = _unit getHitIndex _hitIndex;
 };
 
-if (GVAR(damageEhVariant) isNotEqualTo 1 || {!(isDamageAllowed _unit) || {_hitPoint in ["hithead", "hitbody", "hithands", "hitlegs"]}}) exitWith {_curDamage};
+if (GVAR(damageEhVariant) isNotEqualTo 1 || {!(isDamageAllowed _unit)}) exitWith {_curDamage};
 
 private _newDamage = _damage - _curDamage;
 if (_newDamage isEqualTo 0) exitWith {
@@ -67,5 +67,25 @@ _hitPoint = [_hitPoint, "hit", ""] call CBA_fnc_replace;
 private _var = format ["GVAR(lastHandleDamage)$%1", _hitPoint];
 if ((_unit getVariable [_var, -1]) isEqualTo _realDamage) exitWith {_curDamage};
 _unit setVariable [_var, _realDamage];
-[_unit, _realDamage, _hitPoint, [_source, _instigator] select (isNull _source)] call FUNC(receiveDamage);
+
+if (GVAR(useHandleDamageFiltering)) then {
+    private _damageCache = _unit getVariable [QGVAR(damageCache), []];
+    if (_damageCache isEqualTo []) then {
+        _unit setVariable [QGVAR(damageCache), _damageCache];
+        [{
+            params ["_unit", "_source"];
+            private _damageCache = _unit getVariable [QGVAR(damageCache), []];
+            if (_damageCache isNotEqualTo []) then {
+                _damageCache sort false;
+                (_damageCache select 0) params ["_realDamage", "_hitPoint"];
+                [_unit, _realDamage, _hitPoint, _source] call FUNC(receiveDamage);
+            };
+            _unit setVariable [QGVAR(damageCache), nil];
+        }, [_unit, [_source, _instigator] select (isNull _source)]] call CBA_fnc_execNextFrame;
+    };
+    _damageCache pushBack [_realDamage, _hitPoint];
+} else {
+    [_unit, _realDamage, _hitPoint, [_source, _instigator] select (isNull _source)] call FUNC(receiveDamage);
+};
+
 0

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -266,6 +266,15 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(useHandleDamageFiltering),
+    "CHECKBOX",
+    [LLSTRING(useHandleDamageFiltering), LLSTRING(useHandleDamageFiltering_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(enablePlayerUnconscious),
     "CHECKBOX",
     [LLSTRING(enablePlayerUnconscious), LLSTRING(enablePlayerUnconscious_desc)],

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -439,5 +439,11 @@
         <Key ID="STR_diw_armor_plates_main_requestAIforHelp_desc">
             <English>Enables the abillity for AI to revive unconscious squad mates</English>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_useHandleDamageFiltering">
+            <English>Filter HandleDamage EH</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_useHandleDamageFiltering_desc">
+            <English>Adds a filter to only pass highest damage value when using HandleDamage as damage EH. Makes HandleDamage much more predictable, less chaotic but also less damaging overall</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Caches all incoming damage of current frame, then evaluates them the next frame.  Only the highest damage will then be passed to the receiveDamage function.

Makes HandleDamage much more predictable and less chaotic. However damage modifiers need to be adjusted then.