### PR TITLE
Add a visible bleedout timer over the downed icon

### DIFF
--- a/addons/main/functions/fnc_drawDownedUnitIndicator.sqf
+++ b/addons/main/functions/fnc_drawDownedUnitIndicator.sqf
@@ -8,10 +8,16 @@ private _color = [
     profileNamespace getvariable ['igui_error_RGB_B', 0.1],
     profileNamespace getvariable ['igui_error_RGB_A', 1]
 ];
+private _isMedic = (call CBA_fnc_currentUnit) getUnitTrait "Medic";
 
 {
     private _distance = _x distance _camPos;
     if (_distance > GVAR(showDownedUnitIndicatorRange)) then {continue};
     private _sizeFinal = linearConversion [0, GVAR(showDownedUnitIndicatorRange), _distance, _size, _size/10, false];
     drawIcon3D [["\a3\ui_f\data\igui\cfg\actions\bandage_ca.paa", "\A3\ui_f\data\Map\VehicleIcons\pictureHeal_ca.paa"] select (_x getVariable [QGVAR(beingRevived), false]), _color, (ASLtoAGL visiblePositionASL _x) vectorAdd [0, 0, 0.5], _sizeFinal, _sizeFinal, 0, "", 0, 0, "RobotoCondensed", "center", true, 0, 0.5];
+    if (_distance > GVAR(bleedoutTimerRange)) then {continue};
+    private _timeRemaining = round ((_x getVariable [QGVAR(bleedoutKillTime), -1]) - cba_missionTime);
+    if (_timeRemaining >= 0 && { GVAR(visibleBleedoutTimer) > 0 && { _isMedic || GVAR(visibleBleedoutTimer) == 2 } }) then {
+        drawIcon3D ["", [1, 1, 1, 1], (ASLtoAGL visiblePositionASL _x) vectorAdd [0, 0, 0.5], 0, 0, 0, str _timeRemaining, 2, 0.06, "RobotoCondensed", "center", false, -0.0005, -0.015];
+    };
 } forEach (GVAR(downedUnitIndicatorDrawCache) select {_x getVariable [QGVAR(unconscious), false]});

--- a/addons/main/functions/fnc_drawDownedUnitIndicator.sqf
+++ b/addons/main/functions/fnc_drawDownedUnitIndicator.sqf
@@ -1,7 +1,6 @@
 #include "script_component.hpp"
 
-private _zoom = (call CBA_fnc_getFov) select 1;
-private _size = GVAR(showDownedUnitIndicatorSize) * _zoom;
+private _size = GVAR(showDownedUnitIndicatorSize) * ((call CBA_fnc_getFov) select 1);
 private _camPos = positionCameraToWorld [0, 0, 0];
 private _color = [
     profileNamespace getvariable ['igui_error_RGB_R', 1],
@@ -19,6 +18,6 @@ private _isMedic = (call CBA_fnc_currentUnit) getUnitTrait "Medic";
     if (_distance > GVAR(bleedoutTimerRange)) then {continue};
     private _timeRemaining = round ((_x getVariable [QGVAR(bleedoutKillTime), -1]) - cba_missionTime);
     if (_timeRemaining >= 0 && { GVAR(visibleBleedoutTimer) > 0 && { _isMedic || GVAR(visibleBleedoutTimer) == 2 } }) then {
-        drawIcon3D ["", [1, 1, 1, 1], (ASLtoAGL visiblePositionASL _x) vectorAdd [0, 0, 0.5], 0, 0, 0, str _timeRemaining, 2, 0.06 * _zoom, "RobotoCondensed", "center", false, -0.0005, -0.015 * _zoom];
+        drawIcon3D ["", [1, 1, 1, 1], (ASLtoAGL visiblePositionASL _x) vectorAdd [0, 0, 0.5], 0, 0, 0, str _timeRemaining, 2, 0.06 * (_size/2), "RobotoCondensed", "center", false, -0.0005 * (_size/2), -0.015 * (_size/2)];
     };
 } forEach (GVAR(downedUnitIndicatorDrawCache) select {_x getVariable [QGVAR(unconscious), false]});

--- a/addons/main/functions/fnc_drawDownedUnitIndicator.sqf
+++ b/addons/main/functions/fnc_drawDownedUnitIndicator.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
-private _size = GVAR(showDownedUnitIndicatorSize) * ((call CBA_fnc_getFov) select 1);
+private _zoom = (call CBA_fnc_getFov) select 1;
+private _size = GVAR(showDownedUnitIndicatorSize) * _zoom;
 private _camPos = positionCameraToWorld [0, 0, 0];
 private _color = [
     profileNamespace getvariable ['igui_error_RGB_R', 1],
@@ -18,6 +19,6 @@ private _isMedic = (call CBA_fnc_currentUnit) getUnitTrait "Medic";
     if (_distance > GVAR(bleedoutTimerRange)) then {continue};
     private _timeRemaining = round ((_x getVariable [QGVAR(bleedoutKillTime), -1]) - cba_missionTime);
     if (_timeRemaining >= 0 && { GVAR(visibleBleedoutTimer) > 0 && { _isMedic || GVAR(visibleBleedoutTimer) == 2 } }) then {
-        drawIcon3D ["", [1, 1, 1, 1], (ASLtoAGL visiblePositionASL _x) vectorAdd [0, 0, 0.5], 0, 0, 0, str _timeRemaining, 2, 0.06, "RobotoCondensed", "center", false, -0.0005, -0.015];
+        drawIcon3D ["", [1, 1, 1, 1], (ASLtoAGL visiblePositionASL _x) vectorAdd [0, 0, 0.5], 0, 0, 0, str _timeRemaining, 2, 0.06 * _zoom, "RobotoCondensed", "center", false, -0.0005, -0.015 * _zoom];
     };
 } forEach (GVAR(downedUnitIndicatorDrawCache) select {_x getVariable [QGVAR(unconscious), false]});

--- a/addons/main/functions/fnc_setUnconscious.sqf
+++ b/addons/main/functions/fnc_setUnconscious.sqf
@@ -41,6 +41,7 @@ if (_set) then {
                 };
             };
         }, [_unit, cba_missionTime], _restBleedout] call CBA_fnc_waitAndExecute;
+        _unit setVariable [QGVAR(bleedoutKillTime), cba_missionTime + _restBleedout, true];
         if (GVAR(showDownedSkull) && {_unit isEqualTo player}) then {
             [_set, _restBleedout] call FUNC(showDownedSkull);
         };
@@ -48,6 +49,7 @@ if (_set) then {
 } else {
     _unit setVariable [QGVAR(bleedoutTime), nil];
     _unit setVariable [QGVAR(beingRevived), nil, true];
+    _unit setVariable [QGVAR(bleedoutKillTime), nil, true];
     if (GVAR(showDownedSkull) && {_unit isEqualTo player}) then {
         [_set] call FUNC(showDownedSkull);
     };

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -212,7 +212,7 @@ _category = [_header, LLSTRING(subCategoryFeedback)];
     "LIST",
     [LLSTRING(visibleBleedoutTimer), LLSTRING(visibleBleedoutTimer_desc)],
     _category,
-    [[0, 1, 2], ["str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_nobody_0", "str_a3_rscdisplaycampaignlobby_mediconly", "str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_everyone_0"], 0],
+    [[0, 1, 2], ["str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_nobody_0", "str_a3_rscdisplaycampaignlobby_mediconly", "str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_everyone_0"], 1],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -363,6 +363,28 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
     true
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(visibleBleedoutTimer),
+    "LIST",
+    [LLSTRING(visibleBleedoutTimer), LLSTRING(visibleBleedoutTimer_desc)],
+    _category,
+    [[0, 1, 2], ["str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_nobody_0", "str_a3_rscdisplaycampaignlobby_mediconly", "str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_everyone_0"], 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(bleedoutTimerRange),
+    "SLIDER",
+    [LLSTRING(bleedoutTimerRange), LLSTRING(bleedoutTimerRange_desc)],
+    _category,
+    [0, 500, 100, 0],
+    false,
+    {
+        params ["_value"];
+        GVAR(bleedoutTimerRange) = round _value;
+    }
+] call CBA_fnc_addSetting;
+
 _category = [_header, LLSTRING(subCategoryHealth)];
 
 [

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -208,6 +208,28 @@ _category = [_header, LLSTRING(subCategoryFeedback)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(visibleBleedoutTimer),
+    "LIST",
+    [LLSTRING(visibleBleedoutTimer), LLSTRING(visibleBleedoutTimer_desc)],
+    _category,
+    [[0, 1, 2], ["str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_nobody_0", "str_a3_rscdisplaycampaignlobby_mediconly", "str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_everyone_0"], 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(bleedoutTimerRange),
+    "SLIDER",
+    [LLSTRING(bleedoutTimerRange), LLSTRING(bleedoutTimerRange_desc)],
+    _category,
+    [0, 500, 100, 0],
+    false,
+    {
+        params ["_value"];
+        GVAR(bleedoutTimerRange) = round _value;
+    }
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(showGiveUpDialog),
     "CHECKBOX",
     [LLSTRING(showGiveUpDialog), LLSTRING(showGiveUpDialog_desc)],
@@ -361,28 +383,6 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
     _category,
     false,
     true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(visibleBleedoutTimer),
-    "LIST",
-    [LLSTRING(visibleBleedoutTimer), LLSTRING(visibleBleedoutTimer_desc)],
-    _category,
-    [[0, 1, 2], ["str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_nobody_0", "str_a3_rscdisplaycampaignlobby_mediconly", "str_a3_cfgvehicles_modulesector_f_arguments_taskowner_values_everyone_0"], 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(bleedoutTimerRange),
-    "SLIDER",
-    [LLSTRING(bleedoutTimerRange), LLSTRING(bleedoutTimerRange_desc)],
-    _category,
-    [0, 500, 100, 0],
-    false,
-    {
-        params ["_value"];
-        GVAR(bleedoutTimerRange) = round _value;
-    }
 ] call CBA_fnc_addSetting;
 
 _category = [_header, LLSTRING(subCategoryHealth)];

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -715,5 +715,17 @@
             <Chinesesimp>在完全执行&quot;放弃&quot;动作时显示一个确认对话框。</Chinesesimp>
             <Chinese>在完全執行&quot;放棄&quot;動作時顯示一個確認對話框。</Chinese>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_visibleBleedoutTimer">
+            <English>Show bleedout timer to</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_visibleBleedoutTimer_desc">
+            <English>Applicable players will see a countdown over the wounded icon displaying the time until death.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_bleedoutTimerRange">
+            <English>Range for bleed out timer</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_bleedoutTimerRange_desc">
+            <English>The maximum range you can see the countdown to death over the downed icon.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
This PR adds a configuration option to enable a countdown to appear over the downed icon, showing the time until death. This can be configured to show for nobody (default), for medics only, or for everyone. You can also set a range for its visibility, in case you want to make it so you have to get closer than the icon range to see the timer. (If it's set to a higher range than the icon, it will be capped by the icon's range.)