### PR TITLE
Fix FAKs not being used on heal

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -74,8 +74,9 @@ if (GVAR(aceMedicalLoaded)) then {
 
     ["CAManBase", "HandleHeal", {
         [{
-            (_this select 0) setDamage 0;
-            _this call FUNC(handleHealEh);
+            params ["_unit", "_healer"];
+            _unit setDamage 0;
+            [_unit, _healer, true] call FUNC(handleHealEh);
         }, _this, 5] call CBA_fnc_waitAndExecute;
         true
     }, true, [], true] call CBA_fnc_addClassEventHandler;
@@ -83,6 +84,13 @@ if (GVAR(aceMedicalLoaded)) then {
     [QGVAR(heal), {
         (_this select 0) setDamage 0;
         _this call FUNC(handleHealEh);
+    }] call CBA_fnc_addEventHandler;
+    
+    [QGVAR(consumeFAK), {
+        params ["_unit"];
+        if (([_unit] call FUNC(hasHealItems)) isEqualTo 1) then {
+            _unit removeItem "FirstAidKit";
+        };
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(revive), {

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -29,11 +29,7 @@ private _arr = [_unit, localize "str_heal", "\a3\ui_f\data\IGUI\Cfg\holdactions\
     // codeCompleted
     params ["_target", "_caller"];
     call FUNC(deleteProgressBar);
-    private _ret = [_caller] call FUNC(hasHealItems);
-    if (_ret isEqualTo 1) then {
-        _caller removeItem "FirstAidKit";
-    };
-    [QGVAR(revive), [_target, _caller], _target] call CBA_fnc_targetEvent;
+    [QGVAR(revive), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
     _target setVariable [QGVAR(beingRevived), nil, true];
 }, {
     // code interrupted
@@ -59,10 +55,6 @@ _arr2 call BIS_fnc_holdActionAdd;
     // workaround for mods or missions healing the default a3 damage while the internal health is not at max
     private _id = _unit addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />", {
         params ["", "_caller"];
-        private _healItem = [_caller] call FUNC(hasHealItems);
-        if (_healItem isEqualTo 1) then {
-            _caller removeItem "FirstAidKit";
-        };
         private _isProne = stance _caller == "PRONE";
         private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medic", "AinvPpneMstpSlayW[wpn]Dnon_medic"] select _isProne;
         private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
@@ -73,7 +65,7 @@ _arr2 call BIS_fnc_holdActionAdd;
         [{
             params ["_target", "_caller"];
             if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
-            [QGVAR(heal), [_target, _caller], _target] call CBA_fnc_targetEvent;
+            [QGVAR(heal), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
         }, _this, 5] call CBA_fnc_waitAndExecute;
     }, [], 10, true, true, "", format ["alive _originalTarget && { _originalTarget isNotEqualTo _this && {(damage _originalTarget) isEqualTo 0 && {(_originalTarget getVariable ['%1' , %2]) < (%2 * ([%4, %5] select (_this getUnitTrait 'Medic'))) && {([_this] call %3) > 0}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic)], 2];
     _unit setUserActionText [_id, format [localize "str_a3_cfgactions_healsoldier0", getText ((configOf _unit) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];

--- a/addons/main/functions/fnc_addPlayerHoldActions.sqf
+++ b/addons/main/functions/fnc_addPlayerHoldActions.sqf
@@ -36,10 +36,6 @@
 // workaround for mods or missions healing the default a3 damage while the internal health is not at max
 private _id = player addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />", {
     params ["_target"];
-    private _healItem = [_target] call FUNC(hasHealItems);
-    if (_healItem isEqualTo 1) then {
-        _target removeItem "FirstAidKit";
-    };
     private _isProne = stance _target == "PRONE";
     private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medic", "AinvPpneMstpSlayW[wpn]Dnon_medic"] select _isProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _target, secondaryWeapon _target, handgunWeapon _target] find currentWeapon _target, "non"];
@@ -50,7 +46,7 @@ private _id = player addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\heal
     [{
         params ["_target"];
         if (!alive _target || {_target getVariable [QGVAR(unconscious), false]}) exitWith {};
-        [QGVAR(heal), [_target, _target]] call CBA_fnc_localEvent;
+        [QGVAR(heal), [_target, _target, true]] call CBA_fnc_localEvent;
     }, _this, 5] call CBA_fnc_waitAndExecute;
 }, [], 10, true, true, "", format ["alive _target && {_originalTarget isEqualTo _this && {(damage _target) isEqualTo 0 && {(_target getVariable ['%1' , %2]) < (%2 * ([%4, %5] select (_target getUnitTrait 'Medic'))) && {([_target] call %3) > 0}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic)], 2];
 player setUserActionText [_id, localize "str_a3_cfgactions_healsoldierself0", "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];
@@ -70,11 +66,7 @@ private _arr = [player, LLSTRING(allowSelfRevive_action), "\a3\ui_f\data\IGUI\Cf
     // codeCompleted
     params ["_target"];
     call FUNC(deleteProgressBar);
-    private _ret = [_target] call FUNC(hasHealItems);
-    if (_ret isEqualTo 1) then {
-        _target removeItem "FirstAidKit";
-    };
-    [QGVAR(revive), [_target, _target], _target] call CBA_fnc_localEvent;
+    [QGVAR(revive), [_target, _target, true], _target] call CBA_fnc_localEvent;
 }, {
     // code interrupted
     call FUNC(deleteProgressBar);

--- a/addons/main/functions/fnc_handleHealEh.sqf
+++ b/addons/main/functions/fnc_handleHealEh.sqf
@@ -3,10 +3,10 @@
     params ["_unit"];
     (damage _unit) isEqualTo 0 || {!alive _unit}
 },{
-    params ["_unit", "_healer"];
+    params ["_unit", "_healer", "_consumeFAK"];
     if !(alive _unit) exitWith {};
     if !(local _unit) exitWith {
-        [QGVAR(heal), [_unit, _healer], _unit] call CBA_fnc_targetEvent;
+        [QGVAR(heal), [_unit, _healer, _consumeFAK], _unit] call CBA_fnc_targetEvent;
     };
     if ((lifeState _unit) == "INCAPACITATED" || {_unit getVariable [QGVAR(unconscious), false]}) exitWith {};
 
@@ -27,6 +27,9 @@
     [_unit, _newHp, _maxHp] call FUNC(setA3Damage);
     if ((call CBA_fnc_currentUnit) isEqualTo _unit) then {
         [_unit] call FUNC(updateHPUi);
+    };
+    if (_consumeFAK) then {
+        [QGVAR(consumeFAK), [_healer], _healer] call CBA_fnc_targetEvent;
     };
 }, _this, 10, {
     params ["_unit", "_healer"];

--- a/addons/main/functions/fnc_moduleHeal.sqf
+++ b/addons/main/functions/fnc_moduleHeal.sqf
@@ -14,9 +14,9 @@ if (GVAR(aceMedicalLoaded)) then {
     ["ace_medical_treatment_fullHealLocal", [_unit], _unit] call CBA_fnc_targetEvent;
 } else {
     if ((lifeState _unit) == "INCAPACITATED" || {_unit getVariable [QGVAR(unconscious), false]}) then {
-        [_unit, _unit] call FUNC(revive);
+        [_unit, _unit, false] call FUNC(revive);
     } else {
         _unit setDamage 0;
-        [_unit, _unit] call FUNC(handleHealEh);
+        [_unit, _unit, false] call FUNC(handleHealEh);
     };
 };

--- a/addons/main/functions/fnc_revive.sqf
+++ b/addons/main/functions/fnc_revive.sqf
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
-params ["_unit", "_healer"];
+params ["_unit", "_healer", "_consumeFAK"];
 if !(alive _unit) exitWith {};
 if !(local _unit) exitWith {
-    [QGVAR(revive), [_unit, _healer], _unit] call CBA_fnc_targetEvent;
+    [QGVAR(revive), [_unit, _healer, _consumeFAK], _unit] call CBA_fnc_targetEvent;
 };
 
 private _unconcious = (lifeState _unit) == "INCAPACITATED" || {_unit getVariable [QGVAR(unconscious), false]};
@@ -10,6 +10,10 @@ private _unconcious = (lifeState _unit) == "INCAPACITATED" || {_unit getVariable
 if !(_unconcious) exitWith {};
 
 [_unit, false] call FUNC(setUnconscious);
+//reviving would normally consume a medkit regardless of regen status, so consume it here b/c handleHealEh will not be called if HP regen is on
+if (_consumeFAK) then {
+    [QGVAR(consumeFAK), [_healer], _healer] call CBA_fnc_targetEvent;
+};
 if (GVAR(enableHpRegen)) then {
     if (isPlayer _unit) then {
         [_unit] call FUNC(startHpRegen);
@@ -18,10 +22,10 @@ if (GVAR(enableHpRegen)) then {
             [_unit] call FUNC(startHpRegen);
         } else {
             _unit setDamage 0;
-            [_unit, _healer] call FUNC(handleHealEh);
+            [_unit, _healer, false] call FUNC(handleHealEh);
         };
     };
 } else {
     _unit setDamage 0;
-    [_unit, _healer] call FUNC(handleHealEh);
+    [_unit, _healer, false] call FUNC(handleHealEh);
 };


### PR DESCRIPTION
Moved the code for removing a FAK from the player's inventory from the revive code to the handleHeal code. This should make no functional difference to reviving because reviving heals the player at the end of the action anyway, and it will correct the issue #39 where healing players does not consume the FAK.