### PR TITLE
disable third party medical if possible

### DIFF
--- a/addons/main/CfgFunctions.hpp
+++ b/addons/main/CfgFunctions.hpp
@@ -1,0 +1,10 @@
+class CfgFunctions {
+    class A3_Mark {
+        class Revive {
+            class reviveInit {
+                // Disable BI medical system
+                postInit = 0;
+            };
+        };
+    };
+};

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -19,6 +19,7 @@ if (GVAR(aceMedicalLoaded)) then {
     PREP(addPlayerHoldActions);
     PREP(aiMoveAndHealUnit);
     PREP(canRevive);
+    PREP(disableThirdParty);
     PREP(drawDownedUnitIndicator);
     PREP(getHitpointArmor);
     PREP(getItemArmor);

--- a/addons/main/XEH_preInit.sqf
+++ b/addons/main/XEH_preInit.sqf
@@ -12,6 +12,7 @@ if (GVAR(aceMedicalLoaded)) then {
 } else {
     #include "initSettings.sqf"
 
+    [] call FUNC(disableThirdParty);
     GVAR(armorCache) = false call CBA_fnc_createNamespace;
 };
 

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -20,3 +20,4 @@ class CfgPatches {
 #include "CfgSounds.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgFunctions.hpp"

--- a/addons/main/functions/fnc_disableThirdParty.sqf
+++ b/addons/main/functions/fnc_disableThirdParty.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: BaerMitUmlaut
+ * Detects and disables third party medical systems. Original script from ACE3
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+
+// SOG:PF CDLC revive system
+// Pretend revive system was already initialized.
+// See: vn_fnc_module_advancedrevive
+vn_advanced_revive_started = true;
+
+// Farooq Revive
+// Overwrite player initialization.
+far_player_init = compileFinal "";
+[{!isNil "far_debugging"}, {
+    far_isDragging = nil;  // Disable "Drag & Carry animation fix" loop - cannot be killed because spawned while true.
+    far_muteRadio = nil;   // Disable initialization hint.
+    far_muteACRE = nil;    // Same, but for very old versions.
+    far_debugging = false; // Disable adding event handlers to AI in SP.
+}, [], 5] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
Script from ACE3, should cover SOG prairie fire, FARs revive (used in DRO and DCO) and vanilla arma apex revive

any other is not covered,

Looked into antistasi and it is not possible to disable it there.