### PR TITLE
Adjust plate/HP UI when player enters a vehicle

### DIFF
--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -8,6 +8,7 @@ PREP(initAIUnit);
 PREP(initPlates);
 PREP(moduleHeal);
 PREP(showDamageFeedbackMarker);
+PREP(updateCtrlPosition);
 PREP(updateHPUi);
 PREP(updatePlateUi);
 

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -93,6 +93,7 @@ if (GVAR(aceMedicalLoaded)) then {
         if !(hasInterface) exitWith {};
         params ["_unit"];
         [_unit] call FUNC(addActionsToUnit);
+        [_unit, uiNamespace getVariable [QGVAR(mainControl), controlNull]] call FUNC(fnc_updateCtrlPosition);
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(switchMove), {
@@ -129,6 +130,15 @@ if (GVAR(aceMedicalLoaded)) then {
             _object setUnitTrait ["camouflageCoef", _vis];
         };
     }] call CBA_fnc_addEventHandler;
+    
+    // event handlers for fixing plate UI in vehicles
+    ["CAManBase", "GetInMan", {
+        [_this select 0, uiNamespace getVariable [QGVAR(mainControl), controlNull]] call FUNC(updateCtrlPosition);
+    }, true, [], true] call CBA_fnc_addClassEventHandler;
+    
+    ["CAManBase", "GetOutMan", {
+        [_this select 0, uiNamespace getVariable [QGVAR(mainControl), controlNull]] call FUNC(updateCtrlPosition);
+    }, true, [], true] call CBA_fnc_addClassEventHandler;
 };
 
 if !(hasInterface) exitWith {
@@ -150,6 +160,7 @@ if !(isNil "ace_common_fnc_addActionEventHandler") then {
     params ["_newUnit", "_oldUnit"];
     [_newUnit] call FUNC(updatePlateUi);
     [_newUnit] call FUNC(updateHPUi);
+    [_newUnit, uiNamespace getVariable [QGVAR(mainControl), controlNull]] call FUNC(updateCtrlPosition);
     if !(isNil QGVAR(weaponsEvtId)) then {
         [_oldUnit, "DefaultAction", GVAR(weaponsEvtId)] call ace_common_fnc_removeActionEventHandler;
         GVAR(weaponsEvtId) = [_newUnit, "DefaultAction", {!GVAR(addPlateKeyUp)}, {}] call ace_common_fnc_addActionEventHandler;

--- a/addons/main/functions/fnc_updateCtrlPosition.sqf
+++ b/addons/main/functions/fnc_updateCtrlPosition.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+params ["_unit", "_ctrlGroup"];
+private _stanceDisplay = uiNamespace getVariable [QGVAR(stanceDisplay), displayNull];
+if (isNull _stanceDisplay) then {
+    private _guiDisplay = uiNamespace getVariable ["IGUI_displays", []];
+    private _index = _guiDisplay findIf {(str _x) == "Display #303"};
+    if (_index isNotEqualTo -1) then {
+        _stanceDisplay = _guiDisplay select _index;
+        uiNamespace setVariable [QGVAR(stanceDisplay), _stanceDisplay];
+    };
+};
+
+if !(isNull _ctrlGroup) then {
+    // default to infantry position
+    private _ctrlx = (profileNamespace getVariable ["IGUI_GRID_STAMINA_X", ((safezoneX + safezoneW) - (10 * ( ((safezoneW / safezoneH) min 1.2) / 40)) - 4.3 * ( ((safezoneW / safezoneH) min 1.2) / 40))]);
+    if (!(isNull _stanceDisplay) && { !(isNull _unit) && { vehicle _unit != _unit } }) then {
+        _ctrlx = _ctrlx + (ctrlPosition (_stanceDisplay displayCtrl 188) select 2);
+    };
+    private _ctrly = (profileNamespace getVariable ["IGUI_GRID_STAMINA_Y", (safezoneY + 4.05 * ( ( ((safezoneW / safezoneH) min 1.2) / 1.2) / 25))]);
+    _ctrly = _ctrly + GVAR(fullHeight);
+    _ctrlGroup ctrlSetPosition [_ctrlx, _ctrly, GVAR(fullWidth), GVAR(fullHeight)];
+    _ctrlGroup ctrlCommit 0;
+    true;
+} else { false };


### PR DESCRIPTION
Known issues: since the stance widget doesn't exist until it would be displayed on the player's screen, it can't be used to offset the UI, so if the player starts a mission inside a vehicle their UI won't be adjusted.

![image](https://user-images.githubusercontent.com/20873000/130483742-08014536-e949-4c4f-ad07-2ca8d81568f0.png)

Fixes #51 