### PR TITLE
Use headshot multiplier for neck and add Pelvis multiplier

### DIFF
--- a/addons/main/functions/fnc_receiveDamage.sqf
+++ b/addons/main/functions/fnc_receiveDamage.sqf
@@ -19,6 +19,7 @@ switch (_bodyPart) do {
     case "face_hub";
     case "face";
     case "head": {_isHeadshot = _damage > 0.5; _damage = _damage * GVAR(headshotMult)};
+    case "neck": {_damage = _damage * GVAR(headshotMult)};
     case "arms";
     case "hands";
     case "legs": {_damage = _damage * GVAR(limbMult)};

--- a/addons/main/functions/fnc_receiveDamage.sqf
+++ b/addons/main/functions/fnc_receiveDamage.sqf
@@ -22,6 +22,7 @@ switch (_bodyPart) do {
     case "neck": {_damage = _damage * GVAR(headshotMult)};
     case "arms";
     case "hands";
+    case "pelvis": {_isTorso = true; _damage = _damage * GVAR(pelvisMult)};
     case "legs": {_damage = _damage * GVAR(limbMult)};
     case "vehicle";
     case "incapacitated";

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -310,6 +310,15 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(pelvisMult),
+    "SLIDER",
+    [LLSTRING(pelvisMult), LLSTRING(pelvisMult_desc)],
+    _category,
+    [0, 10, 0.5, 0, true],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(disallowFriendfire),
     "CHECKBOX",
     [LLSTRING(disallowFriendfire), LLSTRING(disallowFriendfire_desc)],

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -283,6 +283,12 @@
             <Chinesesimp>肢体中弹时受到的伤害倍数</Chinesesimp>
             <Chinese>肢體中彈時受到的傷害倍數</Chinese>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_pelvisMult">
+            <English>Pelvis Multiplier</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_pelvisMult_desc">
+            <English>Damage multiplier on pelvis shots</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_disallowFriendfire">
             <English>Disallow friendly fire</English>
             <Polish>Wyłącz ogień przyjacielski</Polish>


### PR DESCRIPTION
Neck hits are lethal even when head takes multiple shots, with the HandleDamage Filter active. Similar case for the pelvis.