### PR TITLE
Boosted maxHp heal / Range bump

### DIFF
--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -81,6 +81,8 @@ _arr2 call BIS_fnc_holdActionAdd;
             if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
             [QGVAR(heal), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
         }, _this, 5] call CBA_fnc_waitAndExecute;
-    }, [], 10, true, true, "", format ["alive _originalTarget && { _originalTarget isNotEqualTo _this && {(damage _originalTarget) isEqualTo 0 && {(_originalTarget getVariable ['%1' , %2]) < (%2 * ([%4, %5] select (_this getUnitTrait 'Medic'))) && {([_this] call %3) > 0}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic)], 2];
+    }, [], 10, true, true, "",
+    format ["!(_originalTarget getVariable ['%6',false]) && {alive _originalTarget && { _originalTarget isNotEqualTo _this && {(damage _originalTarget) isEqualTo 0 && {(_originalTarget getVariable ['%1' , %2]) < (_originalTarget getVariable ['%7', ([%8,%2] select (isPlayer _originalTarget)) * ([%4, %5] select (_this getUnitTrait 'Medic'))]) && {([_this] call %3) > 0}}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
+    3];
     _unit setUserActionText [_id, format [localize "str_a3_cfgactions_healsoldier0", getText ((configOf _unit) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];
 // };


### PR DESCRIPTION
Heal action wasn't usable when between scripted maxHp and maxPlayerHp/maxAiHp.
Range increase, 2 -> 3, because the target's body takes up some of the range.