### PR TITLE
Remove `setUnconscious` call when player bleeds out

### DIFF
--- a/addons/main/functions/fnc_setUnconscious.sqf
+++ b/addons/main/functions/fnc_setUnconscious.sqf
@@ -38,7 +38,6 @@ if (_set) then {
             private _unconscious = (lifeState _unit) == "INCAPACITATED";
             if ((_unit getVariable [QGVAR(bleedoutTime), -1]) isEqualTo _time && {_unconscious}) then {
                 // kill them
-                [_unit, false] call FUNC(setUnconscious);
                 _unit setHitPointDamage ["hitHead", 1, true, _unit];
             } else {
                 if (alive _unit && {_unit getVariable [QGVAR(unconscious), false] && {!_unconscious}}) then {


### PR DESCRIPTION
This should fix the wacky ragdoll when someone bleeds out, which comes from the `switchMove` calls right before dying.
The other places where a player dies don't call `setUnconscious`, so it shouldn't be necessary here, right?