### PR TITLE
Hold Action Priority/Range Settings

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -398,7 +398,7 @@ if !(GVAR(aceMedicalLoaded)) then {
                 params ["_target", "_player", ""];
                 !(_target getVariable [QGVAR(beingRevived), false] && {alive (_target getVariable [QGVAR(revivingUnit), objNull])}) && {[_player, _target] call FUNC(canRevive)}
             },
-            {}, [], [0,0,0], 5,[false,true,false,false,false]
+            {}, [], [0,0,0], GVAR(holdActionRange),[false,true,false,false,false]
         ] call ace_interact_menu_fnc_createAction;
         ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
@@ -461,7 +461,7 @@ if !(GVAR(aceMedicalLoaded)) then {
                 params ["_target", "_player", ""];
                 !(_target getVariable [QGVAR(isHold), false] && {alive (_target getVariable [QGVAR(holdingUnit), objNull])}) && {[_player, _target] call FUNC(canHold)}
             },
-                {}, [], [0,0,0], 5,[false,true,false,false,false]
+                {}, [], [0,0,0], GVAR(holdActionRange),[false,true,false,false,false]
             ] call ace_interact_menu_fnc_createAction;
             ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
         };

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -146,6 +146,6 @@ private _arr3 = [_unit, "Press Wound", "\a3\ui_f\data\IGUI\Cfg\Cursors\unitBleed
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
     _target setVariable [QGVAR(isHold), nil, true];
     _target setVariable [QGVAR(holdingUnit), nil, true];
-}, [], 21.5, 14, false, false, true];
+}, [], 21.5, (14.5 + QGVAR(holdActionPriority)), false, false, true];
 
 _arr3 call BIS_fnc_holdActionAdd;

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -146,6 +146,6 @@ private _arr3 = [_unit, "Press Wound", "\a3\ui_f\data\IGUI\Cfg\Cursors\unitBleed
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
     _target setVariable [QGVAR(isHold), nil, true];
     _target setVariable [QGVAR(holdingUnit), nil, true];
-}, [], 21.5, (14.5 + QGVAR(holdActionPriority)), false, false, true];
+}, [], 21.5, (14.5 + GVAR(holdActionPriority)), false, false, true];
 
 _arr3 call BIS_fnc_holdActionAdd;

--- a/addons/main/functions/fnc_canHold.sqf
+++ b/addons/main/functions/fnc_canHold.sqf
@@ -4,6 +4,6 @@ params ["_unit", "_target"];
 alive _target && {
 _target isNotEqualTo _unit && {
 (lifeState _target) == 'INCAPACITATED' && {
-(_target distance _unit) < 5 && {
+(_target distance _unit) < GVAR(holdActionRange) && {
 !(_unit getVariable ["ace_dragging_isDragging", false]) && {
 !(_unit getVariable ["ace_dragging_isCarrying", false])}}}}}

--- a/addons/main/functions/fnc_canRevive.sqf
+++ b/addons/main/functions/fnc_canRevive.sqf
@@ -4,7 +4,7 @@ params ["_unit", "_target"];
 alive _target && {
 _target isNotEqualTo _unit && {
 (lifeState _target) == 'INCAPACITATED' && {
-(_target distance _unit) < 5 && {
+(_target distance _unit) < GVAR(holdActionRange) && {
 !(_unit getVariable ["ace_dragging_isDragging", false]) && {
 !(_unit getVariable ["ace_dragging_isCarrying", false]) && {
 ([_unit] call FUNC(hasHealItems)) > 0}}}}}}

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -558,6 +558,15 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(holdActionPriority),
+    "LIST",
+    [LLSTRING(holdActionPriority), LLSTRING(holdActionPriority_desc)],
+    _category,
+    [[0, 1], [LLSTRING(holdActionPriority_0), LLSTRING(holdActionPriority_1)], 0],
+    false
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(allowSelfRevive),
     "CHECKBOX",
     [LLSTRING(allowSelfRevive), LLSTRING(allowSelfRevive_desc)],

--- a/addons/main/initSettings.sqf
+++ b/addons/main/initSettings.sqf
@@ -567,6 +567,19 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(holdActionRange),
+    "SLIDER",
+    [LLSTRING(holdActionRange), LLSTRING(holdActionRange_desc)],
+    _category,
+    [0, 12, 5.0, 1],
+    true,
+    {
+        params ["_value"];
+        GVAR(holdActionRange) = (parseNumber (_value toFixed 1));
+    }
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(allowSelfRevive),
     "CHECKBOX",
     [LLSTRING(allowSelfRevive), LLSTRING(allowSelfRevive_desc)],

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -977,6 +977,12 @@
         <Key ID="STR_diw_armor_plates_main_holdActionPriority_1">
             <English>Press Wound</English>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_holdActionRange">
+            <English>Revive/Press Wound range</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_holdActionRange_desc">
+            <English>Range in meters from the target where revive and press wound actions become possible.</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_armorHandlingMode">
             <English>Armor Handling Mode</English>
             <Polish>Tryb pancerza</Polish>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -965,6 +965,18 @@
             <English>The maximum range medics can see the countdown to death over the downed icon.</English>
             <Polish>Maksymalny zasięg, w którym medyk widzi licznik obok ikony rannego.</Polish>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_holdActionPriority">
+            <English>Hold Action Priority</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_holdActionPriority_desc">
+            <English>Whether to prioritize reviving or pressing wound, when both are possible. Needs mission restart.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_holdActionPriority_0">
+            <English>Revive</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_holdActionPriority_1">
+            <English>Press Wound</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_armorHandlingMode">
             <English>Armor Handling Mode</English>
             <Polish>Tryb pancerza</Polish>


### PR DESCRIPTION
Adds a setting for which hold action to prioritize between reviving and pressing wound, for individual players to choose.
Also a setting for the range of hold actions and the ace interact equivalents.