### PR TITLE
Add Plate transfer/CBA Loadout events for mod compatibility, Vest blacklist setting

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -554,6 +554,34 @@ if (_aceInteractLoaded) then {
     ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
 };
 
+/* Plate transfer events for compatibility use
+    Use `"diw_armor_plates_main_transferStart" call CBA_fnc_localEvent;` before altering unit loadout, and 
+    `"diw_armor_plates_main_transfer" call CBA_fnc_localEvent;` after altering the loadout to maintain the
+    player's plates when changing loadout/vest. 
+*/
+[QGVAR(transferStart), {
+    if (isNull (vestContainer player)) exitWith {GVAR(plateTransfer) = nil};
+    GVAR(plateTransfer) = [(vestContainer player),(vestContainer player) getVariable [QGVAR(plates),[]]];
+}] call CBA_fnc_addEventHandler;
+[QGVAR(transfer), {
+	if (isNil QGVAR(plateTransfer) || {isNull (vestContainer player)}) exitWith {GVAR(plateTransfer) = nil;};
+	if ( (vestContainer player) isEqualTo (GVAR(plateTransfer) # 0) ) exitWith {GVAR(plateTransfer) = nil;};
+	(vestContainer player) setVariable [QGVAR(plates),(GVAR(plateTransfer) # 1)];
+	[player] call FUNC(updatePlateUi);
+	GVAR(plateTransfer) = nil;
+}] call CBA_fnc_addEventHandler;
+
+// Ace Arsenal plate transfer
+private _aceArsenalLoaded = !(isNil "ace_arsenal_fnc_openBox");
+if (_aceArsenalLoaded) then {
+    ["ace_arsenal_displayOpened", {
+        "diw_armor_plates_main_transferStart" call CBA_fnc_localEvent;
+    }] call CBA_fnc_addEventHandler;
+    ["ace_arsenal_displayClosed", {
+        "diw_armor_plates_main_transfer" call CBA_fnc_localEvent;
+    }] call CBA_fnc_addEventHandler;
+};
+
 [{
     time > 1
 }, {

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -291,7 +291,7 @@ GVAR(respawnEHId) = ["CAManBase", "Respawn", {
     _unit setVariable [QGVAR(beingRevived), nil, true];
 
     if (_unit isEqualTo player) then {
-        if (GVAR(spawnWithFullPlates)) then {
+        if (GVAR(spawnWithFullPlates) && {!((vest player) in GVAR(vestBlacklist))}) then {
             [{
                 params ["_unit"];
                 [_unit] call FUNC(fillVestWithPlates);
@@ -561,7 +561,7 @@ if (_aceInteractLoaded) then {
 */
 [QGVAR(transferStart), { params [["_unit",player,[objNull]]];
     private _vest = vestContainer _unit;
-    if (isNull _vest) exitWith {};
+    if (isNull _vest || {(vest _unit) in GVAR(vestBlacklist)}) exitWith {};
     GVAR(plateTransfer) = [_unit, (_vest getVariable [QGVAR(plates),[]])];
 }] call CBA_fnc_addEventHandler;
 [QGVAR(transfer), { params [["_unit",player,[objNull]]];
@@ -571,7 +571,7 @@ if (_aceInteractLoaded) then {
     private _unit = (_plates # 0);
     private _plates = (_plates # 1);
     private _vest = vestContainer _unit;
-    if (isNil '_unit' || {isNull _vest}) exitWith {};
+    if (isNil '_unit' || {isNull _vest || {(vest _unit) in GVAR(vestBlacklist)}}) exitWith {};
     _vest setVariable [QGVAR(plates),_plates];
     private _vLoad = _vest getVariable ["ace_movement_vLoad", 0];
     _vest setVariable ["ace_movement_vLoad", _vLoad + (PLATE_MASS * (count _plates)), true];
@@ -596,7 +596,7 @@ if (_aceInteractLoaded) then {
 
 ["CBA_loadoutSet", {
     params ["_unit", "", "_extradata"];
-    if (isNull (vestContainer _unit)) exitWith {};
+    if (isNull (vestContainer _unit) || {(vest _unit) in GVAR(vestBlacklist)}) exitWith {};
     private _plates = _extradata getOrDefault [QGVAR(plates), []];
 
     // setting check
@@ -622,7 +622,7 @@ if (_aceInteractLoaded) then {
 
 ["CBA_loadoutGet", {
     params ["_unit", "", "_extradata"];
-    if (isNull (vestContainer _unit)) exitWith {};
+    if (isNull (vestContainer _unit) || {(vest _unit) in GVAR(vestBlacklist)}) exitWith {};
     private _plates = (vestContainer _unit) getVariable [QGVAR(plates),[]];
     if (_plates isNotEqualTo []) then {
         _extradata set [QGVAR(plates), _plates];
@@ -633,7 +633,7 @@ if (_aceInteractLoaded) then {
     time > 1
 }, {
     private _3den_maxPlateInVest = player getVariable [QGVAR(3den_maxPlateInVest), -1];
-    if (_3den_maxPlateInVest >= 0 || {GVAR(spawnWithFullPlates)}) then {
+    if (_3den_maxPlateInVest >= 0 || {GVAR(spawnWithFullPlates) && {!((vest player) in GVAR(vestBlacklist))}}) then {
         [player] call FUNC(fillVestWithPlates);
     };
     private _3den_maxPlateInInventory = player getVariable [QGVAR(3den_maxPlateInInventory), -1];

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -569,7 +569,9 @@ if (_aceInteractLoaded) then {
     if (isNil QGVAR(plateTransfer) || {isNull (vestContainer player)}) exitWith {GVAR(plateTransfer) = nil;};
     private _vest = vestContainer player;
     if ( _vest isEqualTo (GVAR(plateTransfer) # 0) ) exitWith {GVAR(plateTransfer) = nil;};
-    _vest setVariable [QGVAR(plates),(GVAR(plateTransfer) # 1)];
+    private _plates = (GVAR(plateTransfer) # 1);
+    _vest setVariable [QGVAR(plates),_plates];
+    _vest setVariable ["ace_movement_vLoad", _vLoad + (PLATE_MASS * (count _plates)), true];
     [player] call FUNC(updatePlateUi);
     GVAR(plateTransfer) = nil;
 }] call CBA_fnc_addEventHandler;

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -554,21 +554,23 @@ if (_aceInteractLoaded) then {
     ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
 };
 
+
+
 /* Plate transfer events for compatibility use
-    Use `"diw_armor_plates_main_transferStart" call CBA_fnc_localEvent;` before altering unit loadout, and 
-    `"diw_armor_plates_main_transfer" call CBA_fnc_localEvent;` after altering the loadout to maintain the
-    player's plates when changing loadout/vest. 
+  Use `"diw_armor_plates_main_transferStart" call CBA_fnc_localEvent;` before altering unit loadout, and 
+  `"diw_armor_plates_main_transfer" call CBA_fnc_localEvent;` after altering the loadout to maintain the
+  player's plates when changing loadout/vest.
 */
 [QGVAR(transferStart), {
     if (isNull (vestContainer player)) exitWith {GVAR(plateTransfer) = nil};
     GVAR(plateTransfer) = [(vestContainer player),(vestContainer player) getVariable [QGVAR(plates),[]]];
 }] call CBA_fnc_addEventHandler;
 [QGVAR(transfer), {
-	if (isNil QGVAR(plateTransfer) || {isNull (vestContainer player)}) exitWith {GVAR(plateTransfer) = nil;};
-	if ( (vestContainer player) isEqualTo (GVAR(plateTransfer) # 0) ) exitWith {GVAR(plateTransfer) = nil;};
-	(vestContainer player) setVariable [QGVAR(plates),(GVAR(plateTransfer) # 1)];
-	[player] call FUNC(updatePlateUi);
-	GVAR(plateTransfer) = nil;
+    if (isNil QGVAR(plateTransfer) || {isNull (vestContainer player)}) exitWith {GVAR(plateTransfer) = nil;};
+    if ( (vestContainer player) isEqualTo (GVAR(plateTransfer) # 0) ) exitWith {GVAR(plateTransfer) = nil;};
+    (vestContainer player) setVariable [QGVAR(plates),(GVAR(plateTransfer) # 1)];
+    [player] call FUNC(updatePlateUi);
+    GVAR(plateTransfer) = nil;
 }] call CBA_fnc_addEventHandler;
 
 // Ace Arsenal plate transfer

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -566,7 +566,7 @@ if (_aceInteractLoaded) then {
 }] call CBA_fnc_addEventHandler;
 [QGVAR(transfer), { params [["_unit",player,[objNull]]];
     private _plates = (missionNamespace getVariable [QGVAR(plateTransfer),nil]);
-	if (isNil '_plates') exitWith {};
+    if (isNil '_plates') exitWith {};
     GVAR(plateTransfer) = nil;
     private _unit = (_plates # 0);
     private _plates = (_plates # 1);

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -554,8 +554,6 @@ if (_aceInteractLoaded) then {
     ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
 };
 
-
-
 /* Plate transfer events for compatibility use
   Use `"diw_armor_plates_main_transferStart" call CBA_fnc_localEvent;` before altering unit loadout, and 
   `"diw_armor_plates_main_transfer" call CBA_fnc_localEvent;` after altering the loadout to maintain the

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -559,12 +559,14 @@ if (_aceInteractLoaded) then {
 
   If using vanilla functions, use `diw_armor_plates_main_plateTransferArsenal = true;`, if you want the plateRefillArsenal setting to affect the transfer, then `["diw_armor_plates_main_transferStart",[]] call CBA_fnc_localEvent;` before altering unit loadout, and `["diw_armor_plates_main_transfer",[]] call CBA_fnc_localEvent;` after altering the loadout to maintain the player's plates when changing loadout/vest.
 */
-[QGVAR(transferStart), { params [["_unit",player]];
+[QGVAR(transferStart), { params [["_unit",player,[objNull]]];
+    if (!local _unit) exitWith {[QGVAR(transfer), [_unit], _unit] call CBA_fnc_targetEvent;};
     private _vest = vestContainer _unit;
     if (isNull _vest) exitWith {};
     GVAR(plateTransfer) = [_unit, (_vest getVariable [QGVAR(plates),[]])];
 }] call CBA_fnc_addEventHandler;
-[QGVAR(transfer), {
+[QGVAR(transfer), { params [["_unit",player,[objNull]]];
+    if (!local _unit) exitWith {[QGVAR(transfer), [_unit], _unit] call CBA_fnc_targetEvent;};
     private _plates = (missionNamespace getVariable [QGVAR(plateTransfer),nil]);
     GVAR(plateTransfer) = nil;
     private _unit = (_plates # 0);
@@ -587,13 +589,17 @@ if (_aceInteractLoaded) then {
 // Vanilla arsenal
 [missionNamespace, "arsenalPreOpen", { params ["", "_center"];
     private _unit = nearestObject [_center,"CAManBase"];
+    if (isNull _unit) then {_unit = player};
+    GVAR(transferTarg) = _unit;
     //GVAR(plateTransferArsenal) = true;
-    ["diw_armor_plates_main_transferStart",[]] call CBA_fnc_localEvent;
+    ["diw_armor_plates_main_transferStart",[_unit],_unit] call CBA_fnc_targetEvent;
 }] call BIS_fnc_addScriptedEventHandler;
 
 [missionNamespace, "arsenalClosed", {
     0 spawn { sleep 1;
-        ["diw_armor_plates_main_transfer",[]] call CBA_fnc_localEvent;
+        private _unit = GVAR(transferTarg);
+        GVAR(transferTarg) = nil;
+        ["diw_armor_plates_main_transfer",[_unit],_unit] call CBA_fnc_targetEvent;;
     };
 }] call BIS_fnc_addScriptedEventHandler;
 

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -617,8 +617,7 @@ if (_aceArsenalLoaded) then {
 ["CBA_loadoutGet", {
     params ["_unit", "", "_extradata"];
     if (isNull (vestContainer _unit)) exitWith {};
-    private _plates = [];
-    _plates = (vestContainer _unit) getVariable [QGVAR(plates),[]];
+    private _plates = (vestContainer _unit) getVariable [QGVAR(plates),[]];
     if (_plates isNotEqualTo []) then {
         _extradata set [QGVAR(plates), _plates];
     };

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -571,6 +571,7 @@ if (_aceInteractLoaded) then {
     if ( _vest isEqualTo (GVAR(plateTransfer) # 0) ) exitWith {GVAR(plateTransfer) = nil;};
     private _plates = (GVAR(plateTransfer) # 1);
     _vest setVariable [QGVAR(plates),_plates];
+    private _vLoad = _vest getVariable ["ace_movement_vLoad", 0];
     _vest setVariable ["ace_movement_vLoad", _vLoad + (PLATE_MASS * (count _plates)), true];
     [player] call FUNC(updatePlateUi);
     GVAR(plateTransfer) = nil;

--- a/addons/main/functions/fnc_canAddPlate.sqf
+++ b/addons/main/functions/fnc_canAddPlate.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 params ["_player"];
-if ((vest _player) isEqualTo "") exitWith {false};
+private _vest = vest _player;
+if (_vest isEqualTo "" || {_vest in GVAR(vestBlacklist)}) exitWith {false};
 
 if !(GVAR(hasPlateInInvetory)) exitWith {false};
 

--- a/addons/main/functions/fnc_initAIUnit.sqf
+++ b/addons/main/functions/fnc_initAIUnit.sqf
@@ -6,7 +6,7 @@ if (GVAR(numWearablePlates) isEqualTo 0 || {!local _unit || {isPlayer _unit || {
 [{
     params ["_unit"];
     private _3den_maxPlateInVest = _unit getVariable [QGVAR(3den_maxPlateInVest), -1];
-    if (_3den_maxPlateInVest >= 0 || {GVAR(AIchancePlateInVest) > 0 && {(random 1) < GVAR(AIchancePlateInVest) && {!isNull (vestContainer _unit)}}}) then {
+    if (_3den_maxPlateInVest >= 0 || {GVAR(AIchancePlateInVest) > 0 && {(random 1) < GVAR(AIchancePlateInVest) && {!isNull (vestContainer _unit) && {!((vest _unit) in GVAR(vestBlacklist))}}}}) then {
         private _arr = [];
         private _num = if (_3den_maxPlateInVest >= 0) then {
             _3den_maxPlateInVest min GVAR(numWearablePlates)

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -154,6 +154,18 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     false
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(vestBlacklist),
+    "EDITBOX",
+    [LLSTRING(vestBlacklist), LLSTRING(vestBlacklist_desc)],
+    _category,
+    "",
+    true,
+    {   params ["_value"];
+        GVAR(vestBlacklist) = ([(_value call CBA_fnc_removeWhitespace), ","] call CBA_fnc_split);
+    }
+] call CBA_fnc_addSetting;
+
 _category = [_header, LLSTRING(subCategoryFeedback)];
 
 [

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -163,7 +163,8 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     true,
     {   params ["_value"];
         GVAR(vestBlacklist) = ([(_value call CBA_fnc_removeWhitespace), ","] call CBA_fnc_split);
-    }
+    },
+    true
 ] call CBA_fnc_addSetting;
 
 _category = [_header, LLSTRING(subCategoryFeedback)];

--- a/addons/main/initSettingsACE.inc.sqf
+++ b/addons/main/initSettingsACE.inc.sqf
@@ -168,6 +168,18 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     false
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(vestBlacklist),
+    "EDITBOX",
+    [LLSTRING(vestBlacklist), LLSTRING(vestBlacklist_desc)],
+    _category,
+    "",
+    true,
+    {   params ["_value"];
+        GVAR(vestBlacklist) = ([(_value call CBA_fnc_removeWhitespace), ","] call CBA_fnc_split);
+    }
+] call CBA_fnc_addSetting;
+
 _category = [_header, LLSTRING(subCategoryFeedback)];
 
 [

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -179,6 +179,12 @@
             <English>High</English>
             <Polish>Duża</Polish>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_vestBlacklist">
+            <English>Vest Blacklist</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_vestBlacklist_desc">
+            <English>List of vest class names to have plate insertion disabled. Class names can be found with {vest player} or ctrl+c when selected in ACE arsenal. (ex. vestclassname1, vestclassname2)</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_subCategoryHealth">
             <English>Health</English>
             <Polish>Punkty życia</Polish>


### PR DESCRIPTION
Should allow mods that affect a player's vest/loadout to easily add compatibility with APS. Also adds an example of use with ace arsenal.
Adds Vest Blacklist setting, disabling plate functionality for vests in the list.