### PR TITLE
Add Zeus modules for malus reset/plate fill / Fix HandleHeal

### DIFF
--- a/addons/main/CfgVehicles.hpp
+++ b/addons/main/CfgVehicles.hpp
@@ -42,6 +42,13 @@ class CfgVehicles {
         function = QFUNC(moduleHeal);
         icon = "\A3\ui_f\data\Map\VehicleIcons\pictureHeal_ca.paa";
     };
+    class GVAR(modulePlate): GVAR(moduleBase) {
+        curatorCanAttach = 1;
+        displayName = CSTRING(zeus_module_plate);
+        isGlobal = 0;
+        function = QFUNC(modulePlate);
+        icon = "\a3\ui_f\data\gui\rsc\rscdisplayarsenal\vest_ca.paa";
+    };
     class GVAR(moduleResetMalus): GVAR(moduleBase) {
         curatorCanAttach = 1;
         displayName = CSTRING(zeus_module_malus);

--- a/addons/main/CfgVehicles.hpp
+++ b/addons/main/CfgVehicles.hpp
@@ -45,21 +45,19 @@ class CfgVehicles {
     class GVAR(modulePlate): GVAR(moduleBase) {
         curatorCanAttach = 1;
         displayName = CSTRING(zeus_module_plate);
-        isGlobal = 0;
         function = QFUNC(modulePlate);
         icon = "\a3\ui_f\data\gui\rsc\rscdisplayarsenal\vest_ca.paa";
     };
     class GVAR(moduleResetMalus): GVAR(moduleBase) {
         curatorCanAttach = 1;
         displayName = CSTRING(zeus_module_malus);
-        isGlobal = 0;
         function = QFUNC(moduleResetMalus);
         icon = QPATHTOF(ui\autoInjector_ca.paa);
     };
     class GVAR(moduleResetMalusGlobal): GVAR(moduleBase) {
         curatorCanAttach = 1;
         displayName = CSTRING(zeus_module_malusGlobal);
-        function = "diw_armor_plates_main_bleedOutTimeMalus = nil";
+        function = QFUNC(moduleResetMalusGlobal);
         icon = "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_reviveMedic_ca.paa";
     };
 };

--- a/addons/main/CfgVehicles.hpp
+++ b/addons/main/CfgVehicles.hpp
@@ -42,4 +42,17 @@ class CfgVehicles {
         function = QFUNC(moduleHeal);
         icon = "\A3\ui_f\data\Map\VehicleIcons\pictureHeal_ca.paa";
     };
+    class GVAR(moduleResetMalus): GVAR(moduleBase) {
+        curatorCanAttach = 1;
+        displayName = CSTRING(zeus_module_malus);
+        isGlobal = 0;
+        function = QFUNC(moduleResetMalus);
+        icon = QPATHTOF(ui\autoInjector_ca.paa);
+    };
+    class GVAR(moduleResetMalusGlobal): GVAR(moduleBase) {
+        curatorCanAttach = 1;
+        displayName = CSTRING(zeus_module_malusGlobal);
+        function = "diw_armor_plates_main_bleedOutTimeMalus = nil";
+        icon = "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_reviveMedic_ca.paa";
+    };
 };

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -12,6 +12,7 @@ PREP(initPlates);
 PREP(moduleHeal);
 PREP(modulePlate);
 PREP(moduleResetMalus);
+PREP(moduleResetMalusGlobal);
 PREP(showDamageFeedbackMarker);
 PREP(uniqueItems);
 PREP(updateHPUi);

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -10,6 +10,8 @@ PREP(handleArmorDamage);
 PREP(initAIUnit);
 PREP(initPlates);
 PREP(moduleHeal);
+PREP(modulePlate);
+PREP(moduleResetMalus);
 PREP(showDamageFeedbackMarker);
 PREP(uniqueItems);
 PREP(updateHPUi);

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -77,17 +77,14 @@ if (GVAR(aceMedicalLoaded)) then {
             _unit setVariable [QGVAR(HandleDamageEHID), _id];
         };
 
-        if (_unit getVariable [QGVAR(HandleHealEHID), -1] isEqualTo -1) then {
-            private _id = _unit addEventHandler ["HandleHeal", {
-                [{
-                    params ["_unit", "_healer"];
-                    _unit setDamage 0;
-                    [_unit, _healer, true] call FUNC(handleHealEh);
-                }, _this, 5] call CBA_fnc_waitAndExecute;
-                true
-            }];
-            _unit setVariable [QGVAR(HandleHealEHID), _id];
-        };
+        _unit addEventHandler ["HandleHeal", {
+            [{
+                params ["_unit", "_healer"];
+                _unit setDamage 0;
+                [_unit, _healer, true] call FUNC(handleHealEh);
+            }, _this, 5] call CBA_fnc_waitAndExecute;
+            true
+        }];
 
         [_unit] call FUNC(addActionsToUnit);
         [_unit] call FUNC(initAIUnit);

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -225,12 +225,11 @@ if (GVAR(aceMedicalLoaded)) then {
         };
     }] call CBA_fnc_addEventHandler;
 
-    [QGVAR(resetMalus), {
-        params ["_unit"];
-        if (!alive _unit || {!isPlayer _unit}) exitWith {};
+    [QGVAR(resetMalus), {       
+        if (!alive player) exitWith {};
         GVAR(bleedOutTimeMalus) = nil;
-        if (_unit getVariable [QGVAR(unconscious), false]) then {
-            _unit setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
+        if (player getVariable [QGVAR(unconscious), false]) then {
+            player setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
         };
     }] call CBA_fnc_addEventHandler;
 

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -224,6 +224,22 @@ if (GVAR(aceMedicalLoaded)) then {
             }, _unit, 3] call CBA_fnc_waitAndExecute;
         };
     }] call CBA_fnc_addEventHandler;
+
+    [QGVAR(resetMalus), {
+        params ["_unit"];
+        if (!alive _unit || {!isPlayer _unit}) exitWith {};
+        GVAR(bleedOutTimeMalus) = nil;
+        if (_unit getVariable [QGVAR(unconscious), false]) then {
+            _unit setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
+        };
+    }] call CBA_fnc_addEventHandler;
+
+    [QGVAR(fillPlates), {
+        params ["_unit"];
+        if (!alive _unit) exitWith {};
+        _unit call FUNC(fillVestWithPlates);
+        if (isPlayer _unit) then { _unit call FUNC(updatePlateUi); };
+    }] call CBA_fnc_addEventHandler;
 };
 
 if !(hasInterface) exitWith {

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -77,17 +77,20 @@ if (GVAR(aceMedicalLoaded)) then {
             _unit setVariable [QGVAR(HandleDamageEHID), _id];
         };
 
+        if (_unit getVariable [QGVAR(HandleHealEHID), -1] isEqualTo -1) then {
+            private _id = _unit addEventHandler ["HandleHeal", {
+                [{
+                    params ["_unit", "_healer"];
+                    _unit setDamage 0;
+                    [_unit, _healer, true] call FUNC(handleHealEh);
+                }, _this, 5] call CBA_fnc_waitAndExecute;
+                true
+            }];
+            _unit setVariable [QGVAR(HandleHealEHID), _id];
+        };
+
         [_unit] call FUNC(addActionsToUnit);
         [_unit] call FUNC(initAIUnit);
-    }, true, [], true] call CBA_fnc_addClassEventHandler;
-
-    ["CAManBase", "HandleHeal", {
-        [{
-            params ["_unit", "_healer"];
-            _unit setDamage 0;
-            [_unit, _healer, true] call FUNC(handleHealEh);
-        }, _this, 5] call CBA_fnc_waitAndExecute;
-        true
     }, true, [], true] call CBA_fnc_addClassEventHandler;
 
     [QGVAR(heal), {

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -232,14 +232,14 @@ if (GVAR(aceMedicalLoaded)) then {
             player setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
         };
     }] call CBA_fnc_addEventHandler;
-
-    [QGVAR(fillPlates), {
-        params ["_unit"];
-        if (!alive _unit) exitWith {};
-        _unit call FUNC(fillVestWithPlates);
-        if (isPlayer _unit) then { _unit call FUNC(updatePlateUi); };
-    }] call CBA_fnc_addEventHandler;
 };
+
+[QGVAR(fillPlates), {
+    params ["_unit"];
+    if (!alive _unit) exitWith {};
+    _unit call FUNC(fillVestWithPlates);
+    if (isPlayer _unit) then { _unit call FUNC(updatePlateUi); };
+}] call CBA_fnc_addEventHandler;
 
 if !(hasInterface) exitWith {
     INFO("Dedicated server / Headless client post init done");

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -2,7 +2,7 @@
 class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
-        units[] = {QGVAR(moduleHeal),QGVAR(plateItem),QGVAR(autoInjectorItem)};
+        units[] = {QGVAR(moduleHeal),QGVAR(modulePlate),QGVAR(moduleResetMalus),QGVAR(moduleResetMalusGlobal),QGVAR(plateItem),QGVAR(autoInjectorItem)};
         weapons[] = {QGVAR(plate),QGVAR(autoInjector)};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_main"};

--- a/addons/main/functions/fnc_moduleHeal.sqf
+++ b/addons/main/functions/fnc_moduleHeal.sqf
@@ -6,17 +6,23 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
-if (isNull _unit || {!(_unit isKindOf "CAManBase") || {!alive _unit}}) exitWith {
+private _isObj = (typeName _unit) isEqualTo "OBJECT";
+private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
+if (isNull _unit || { _isPerson && {!alive _unit} }) exitWith {
     [objNull, LLSTRING(zeus_invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 
+if (!_isPerson && {_isObj}) then {_unit = crew _unit;} else {_unit = [_unit]};
+
 if (GVAR(aceMedicalLoaded)) then {
-    ["ace_medical_treatment_fullHealLocal", [_unit], _unit] call CBA_fnc_targetEvent;
+    {["ace_medical_treatment_fullHealLocal", [_x], _x] call CBA_fnc_targetEvent;} forEach _unit;
 } else {
-    if ((lifeState _unit) == "INCAPACITATED" || {_unit getVariable [QGVAR(unconscious), false]}) then {
-        [_unit, _unit, false] call FUNC(revive);
-    } else {
-        _unit setDamage 0;
-        [_unit, _unit, false] call FUNC(handleHealEh);
-    };
+    {
+        if ((lifeState _x) == "INCAPACITATED" || {_x getVariable [QGVAR(unconscious), false]}) then {
+            [_x, _x, false] call FUNC(revive);
+        } else {
+            _x setDamage 0;
+            [_x, _x, false] call FUNC(handleHealEh);
+        };
+    } forEach _unit;
 };

--- a/addons/main/functions/fnc_moduleHeal.sqf
+++ b/addons/main/functions/fnc_moduleHeal.sqf
@@ -20,7 +20,7 @@ if (GVAR(aceMedicalLoaded)) then {
     {
         if !(_x getUnitTrait "Medic") then {
             _x setUnitTrait ["Medic", true];
-            [{  params ["_caller","_isMedic"];
+            [{  params ["_caller"];
                 _caller setUnitTrait ["Medic", false]; 
             }, [_x], 1] call CBA_fnc_waitAndExecute;
         };

--- a/addons/main/functions/fnc_moduleHeal.sqf
+++ b/addons/main/functions/fnc_moduleHeal.sqf
@@ -18,6 +18,12 @@ if (GVAR(aceMedicalLoaded)) then {
     {["ace_medical_treatment_fullHealLocal", [_x], _x] call CBA_fnc_targetEvent;} forEach _unit;
 } else {
     {
+        if !(_x getUnitTrait "Medic") then {
+            _x setUnitTrait ["Medic", true];
+            [{  params ["_caller","_isMedic"];
+                _caller setUnitTrait ["Medic", false]; 
+            }, [_x], 1] call CBA_fnc_waitAndExecute;
+        };
         if ((lifeState _x) == "INCAPACITATED" || {_x getVariable [QGVAR(unconscious), false]}) then {
             [_x, _x, false] call FUNC(revive);
         } else {

--- a/addons/main/functions/fnc_moduleHeal.sqf
+++ b/addons/main/functions/fnc_moduleHeal.sqf
@@ -6,7 +6,7 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
-private _isObj = (typeName _unit) isEqualTo "OBJECT";
+private _isObj = _unit isEqualType objNull;
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
 if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(zeus_invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;

--- a/addons/main/functions/fnc_moduleHeal.sqf
+++ b/addons/main/functions/fnc_moduleHeal.sqf
@@ -8,7 +8,7 @@ deleteVehicle _logic;
 
 private _isObj = (typeName _unit) isEqualTo "OBJECT";
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
-if (isNull _unit || { _isPerson && {!alive _unit} }) exitWith {
+if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(zeus_invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 

--- a/addons/main/functions/fnc_modulePlate.sqf
+++ b/addons/main/functions/fnc_modulePlate.sqf
@@ -12,6 +12,6 @@ if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 
-if (!_isPerson && {_isObj}) then {_unit = crew _unit;};
+if (!_isPerson && {_isObj}) then {_unit = crew _unit;} else {_unit = [_unit]};
 
-[_unit] remoteExec [QFUNC(fillVestWithPlates),_unit];
+{[QGVAR(fillPlates), [_x], _x] call CBA_fnc_targetEvent;} forEach _unit;

--- a/addons/main/functions/fnc_modulePlate.sqf
+++ b/addons/main/functions/fnc_modulePlate.sqf
@@ -9,7 +9,7 @@ deleteVehicle _logic;
 private _isObj = _unit isEqualType objNull;
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
 if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
-    [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
+    [objNull, LLSTRING(zeus_invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 
 if (!_isPerson && {_isObj}) then {_unit = crew _unit;} else {_unit = [_unit]};

--- a/addons/main/functions/fnc_modulePlate.sqf
+++ b/addons/main/functions/fnc_modulePlate.sqf
@@ -6,8 +6,12 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
-if (isNull _unit || {!(_unit isKindOf "CAManBase") || {!alive _unit}}) exitWith {
+private _isObj = (typeName _unit) isEqualTo "OBJECT";
+private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
+if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
+
+if (!_isPerson && {_isObj}) then {_unit = crew _unit;};
 
 [_unit] remoteExec [QFUNC(fillVestWithPlates),_unit];

--- a/addons/main/functions/fnc_modulePlate.sqf
+++ b/addons/main/functions/fnc_modulePlate.sqf
@@ -6,7 +6,7 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
-private _isObj = (typeName _unit) isEqualTo "OBJECT";
+private _isObj = _unit isEqualType objNull;
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
 if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;

--- a/addons/main/functions/fnc_modulePlate.sqf
+++ b/addons/main/functions/fnc_modulePlate.sqf
@@ -1,0 +1,13 @@
+#include "script_component.hpp"
+params ["_logic"];
+
+if !(local _logic) exitWith {};
+
+private _unit = attachedTo _logic;
+deleteVehicle _logic;
+
+if (isNull _unit || {!(_unit isKindOf "CAManBase") || {!alive _unit}}) exitWith {
+    [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
+};
+
+[_unit] remoteExec [QFUNC(fillVestWithPlates),_unit];

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -8,7 +8,7 @@ deleteVehicle _logic;
 
 private _isObj = (typeName _unit) isEqualTo "OBJECT";
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
-if (isNull _unit || { _isPerson && {!alive _unit} }) exitWith {
+if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -13,7 +13,7 @@ if (isNull _unit || {(_unit isKindOf "CAManBase") && {!alive _unit}}) exitWith {
 if (GVAR(aceMedicalLoaded)) exitWith {};
 
 [_unit, { params ["_unit"];
-    if !(_unit isKindOf "CAManBase") {_unit = player;};
+    if !(_unit isKindOf "CAManBase") then {_unit = player;};
     if (!alive _unit) exitWith {};
     diw_armor_plates_main_bleedOutTimeMalus = nil;
     if (_unit getVariable [QGVAR(unconscious), false]) then {

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -6,21 +6,14 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
+if (GVAR(aceMedicalLoaded)) exitWith {};
+
 private _isObj = (typeName _unit) isEqualTo "OBJECT";
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
 if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 
-if (GVAR(aceMedicalLoaded)) exitWith {};
+if (!_isPerson && {_isObj}) then {_unit = crew _unit;} else {_unit = [_unit]};
 
-if (!_isPerson && {_isObj}) then {_unit = crew _unit;};
-
-[_unit, { params ["_unit"];
-    if !(_unit isKindOf "CAManBase") then {_unit = player;};
-    if (!alive _unit) exitWith {};
-    diw_armor_plates_main_bleedOutTimeMalus = nil;
-    if (_unit getVariable [QGVAR(unconscious), false]) then {
-        _unit setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
-    };
-}] remoteExec ["call", _unit];
+{[QGVAR(resetMalus), [_x], _x] call CBA_fnc_targetEvent;} forEach (_unit select {isPlayer _x});

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -6,11 +6,16 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
-if (isNull _unit || {(_unit isKindOf "CAManBase") && {!alive _unit}}) exitWith {
+private _tName = (typeName _unit);
+private _isObj = _tName isEqualTo "OBJECT";
+private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
+if (isNull _unit || { _isPerson && {!alive _unit}}) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 
 if (GVAR(aceMedicalLoaded)) exitWith {};
+
+if (!_isPerson && {_isObj}) then {_unit = crew _unit;};
 
 [_unit, { params ["_unit"];
     if !(_unit isKindOf "CAManBase") then {_unit = player;};

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -6,10 +6,9 @@ if !(local _logic) exitWith {};
 private _unit = attachedTo _logic;
 deleteVehicle _logic;
 
-private _tName = (typeName _unit);
-private _isObj = _tName isEqualTo "OBJECT";
+private _isObj = (typeName _unit) isEqualTo "OBJECT";
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
-if (isNull _unit || { _isPerson && {!alive _unit}}) exitWith {
+if (isNull _unit || { _isPerson && {!alive _unit} }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -8,7 +8,7 @@ deleteVehicle _logic;
 
 if (GVAR(aceMedicalLoaded)) exitWith {};
 
-private _isObj = (typeName _unit) isEqualTo "OBJECT";
+private _isObj = _unit isEqualType objNull;
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
 if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
     [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
@@ -16,4 +16,4 @@ if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
 
 if (!_isPerson && {_isObj}) then {_unit = crew _unit;} else {_unit = [_unit]};
 
-{[QGVAR(resetMalus), [_x], _x] call CBA_fnc_targetEvent;} forEach (_unit select {isPlayer _x});
+{[QGVAR(resetMalus), [], _x] call CBA_fnc_targetEvent;} forEach (_unit select {isPlayer _x});

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -11,7 +11,7 @@ if (GVAR(aceMedicalLoaded)) exitWith {};
 private _isObj = _unit isEqualType objNull;
 private _isPerson = (_isObj && {(_unit isKindOf "CAManBase")});
 if (isNull _unit || { !_isObj || { _isPerson && {!alive _unit} } }) exitWith {
-    [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
+    [objNull, LLSTRING(zeus_invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
 };
 
 if (!_isPerson && {_isObj}) then {_unit = crew _unit;} else {_unit = [_unit]};

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+params ["_logic"];
+
+if !(local _logic) exitWith {};
+
+private _unit = attachedTo _logic;
+deleteVehicle _logic;
+
+if (isNull _unit || {(_unit isKindOf "CAManBase") && {!alive _unit}}) exitWith {
+    [objNull, LLSTRING(invalid_target)] call BIS_fnc_showCuratorFeedbackMessage;
+};
+
+if (GVAR(aceMedicalLoaded)) exitWith {};
+
+[_unit, { params ["_unit"];
+	if !(_unit isKindOf "CAManBase") {_unit = player;};
+    if (!alive _unit) exitWith {};
+    diw_armor_plates_main_bleedOutTimeMalus = nil;
+    if (_unit getVariable [QGVAR(unconscious), false]) then {
+        _unit setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
+    };
+}] remoteExec ["call", _unit];

--- a/addons/main/functions/fnc_moduleResetMalus.sqf
+++ b/addons/main/functions/fnc_moduleResetMalus.sqf
@@ -13,7 +13,7 @@ if (isNull _unit || {(_unit isKindOf "CAManBase") && {!alive _unit}}) exitWith {
 if (GVAR(aceMedicalLoaded)) exitWith {};
 
 [_unit, { params ["_unit"];
-	if !(_unit isKindOf "CAManBase") {_unit = player;};
+    if !(_unit isKindOf "CAManBase") {_unit = player;};
     if (!alive _unit) exitWith {};
     diw_armor_plates_main_bleedOutTimeMalus = nil;
     if (_unit getVariable [QGVAR(unconscious), false]) then {

--- a/addons/main/functions/fnc_moduleResetMalusGlobal.sqf
+++ b/addons/main/functions/fnc_moduleResetMalusGlobal.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+params ["_logic"];
+
+diw_armor_plates_main_bleedOutTimeMalus = nil;
+
+if !(local _logic) exitWith {};
+
+deleteVehicle _logic;
+

--- a/addons/main/functions/fnc_moduleResetMalusGlobal.sqf
+++ b/addons/main/functions/fnc_moduleResetMalusGlobal.sqf
@@ -1,9 +1,8 @@
 #include "script_component.hpp"
 params ["_logic"];
 
-diw_armor_plates_main_bleedOutTimeMalus = nil;
-
 if !(local _logic) exitWith {};
 
 deleteVehicle _logic;
 
+[QGVAR(resetMalus), []] call CBA_fnc_globalEvent;

--- a/addons/main/functions/fnc_moduleResetMalusGlobal.sqf
+++ b/addons/main/functions/fnc_moduleResetMalusGlobal.sqf
@@ -5,4 +5,6 @@ if !(local _logic) exitWith {};
 
 deleteVehicle _logic;
 
+if (GVAR(aceMedicalLoaded)) exitWith {};
+
 [QGVAR(resetMalus), []] call CBA_fnc_globalEvent;

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -813,7 +813,7 @@
             <Chinese>治療單位</Chinese>
         </Key>
         <Key ID="STR_diw_armor_plates_main_zeus_module_plate">
-            <English>Fill unit vest with plates</English>
+            <English>Fill unit/crew vests with plates</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_zeus_module_malus">
             <English>Reset unit/crew bleedout timers</English>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -812,6 +812,15 @@
             <Chinesesimp>治疗单位</Chinesesimp>
             <Chinese>治療單位</Chinese>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_zeus_module_plates">
+            <English>Fill unit vest with plates</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_zeus_module_malus">
+            <English>Reset a unit/group bleedout timers</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_zeus_module_malusGlobal">
+            <English>Reset all player bleedout timers</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_zeus_invalid_target">
             <English>Invalid target selected</English>
             <Polish>Wybrano niepoprawny cel.</Polish>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -807,16 +807,16 @@
             <Chinese>起身</Chinese>
         </Key>
         <Key ID="STR_diw_armor_plates_main_zeus_module_heal">
-            <English>Heal unit</English>
+            <English>Heal unit/crew</English>
             <Polish>Ulecz jednostkę</Polish>
             <Chinesesimp>治疗单位</Chinesesimp>
             <Chinese>治療單位</Chinese>
         </Key>
-        <Key ID="STR_diw_armor_plates_main_zeus_module_plates">
+        <Key ID="STR_diw_armor_plates_main_zeus_module_plate">
             <English>Fill unit vest with plates</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_zeus_module_malus">
-            <English>Reset a unit/group bleedout timers</English>
+            <English>Reset unit/crew bleedout timers</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_zeus_module_malusGlobal">
             <English>Reset all player bleedout timers</English>


### PR DESCRIPTION
Adds zeus modules to allow Zeus to add plates to units and reset bleedout timers.
Also modifies the heal module to be usable on vehicles to heal crews while they are still inside (even while the vehicle is destroyed in non-instant death cases).
Fixes HandleHeal for non-ace, after CBA dropped support for it from cba_fnc_addClassEventHandler. [https://github.com/CBATeam/CBA_A3/pull/1588](url)