### PR TITLE
downState global event / Unlock Heli controls when downed

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -172,6 +172,7 @@ if (GVAR(aceMedicalLoaded)) then {
     [QGVAR(switchMove), {
         params ["_unit", "_anim", ["_weaponReady", true]];
         _unit switchMove _anim;
+        _unit playMoveNow _anim; // clear playMove queue
         if (_weaponReady) then {
             _unit action ["WeaponInHand", _unit];
         };

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -232,6 +232,14 @@ if (GVAR(aceMedicalLoaded)) then {
             player setVariable [QGVAR(bleedoutKillTime),(cba_missionTime + (GVAR(bleedoutTime) - 0)), true];
         };
     }] call CBA_fnc_addEventHandler;
+
+    addMissionEventHandler ["ControlsShifted", {
+        params ["", "", "_vehicle", "_copilotEnabled", "_controlsUnlocked"];
+        if (_copilotEnabled) then { 
+            if !(_controlsUnlocked) exitWith {_vehicle setVariable [QGVAR(controlsUnlocked),nil];};
+            _vehicle setVariable [QGVAR(controlsUnlocked),true];
+        };
+    }];
 };
 
 [QGVAR(fillPlates), {

--- a/addons/main/functions/fnc_setUnconscious.sqf
+++ b/addons/main/functions/fnc_setUnconscious.sqf
@@ -73,6 +73,8 @@ _unit setUnconscious _set;
 [QGVAR(setHidden), [_unit , _set]] call CBA_fnc_globalEvent;
 _unit setVariable [QGVAR(unconscious), _set, true];
 _unit setVariable ["ACE_isUnconscious", _set, true]; // support for ace dragging and other ace features if enabled
+[QGVAR(downState), [_unit, _set]] call CBA_fnc_globalEvent;
+if (_set && {isCopilotEnabled vehicle _unit}) then {_unit action ["UnlockVehicleControl", vehicle _unit];};
 
 if (GVAR(radioModUnconRestrictions) > 0) then {
     // ACRE

--- a/addons/main/functions/fnc_setUnconscious.sqf
+++ b/addons/main/functions/fnc_setUnconscious.sqf
@@ -74,7 +74,6 @@ _unit setUnconscious _set;
 _unit setVariable [QGVAR(unconscious), _set, true];
 _unit setVariable ["ACE_isUnconscious", _set, true]; // support for ace dragging and other ace features if enabled
 [QGVAR(downState), [_unit, _set]] call CBA_fnc_globalEvent;
-if (_set && {isCopilotEnabled vehicle _unit}) then {_unit action ["UnlockVehicleControl", vehicle _unit];};
 
 if (GVAR(radioModUnconRestrictions) > 0) then {
     // ACRE
@@ -99,6 +98,22 @@ if (GVAR(radioModUnconRestrictions) > 0) then {
     if (GVAR(radioModUnconRestrictions) isEqualTo 2) then {
         _unit setVariable ["acre_sys_core_isDisabled", _set, GVAR(AcreLoaded)];
         _unit setVariable ["tf_voiceVolume", [1, 0] select _set, GVAR(TfarLoaded)];
+    };
+};
+
+if (GVAR(pilotUncon) > 0 && {alive _unit}) then {
+    private _vic = vehicle _unit;
+    if (isCopilotEnabled _vic && {driver _vic isEqualTo _unit && {!(_vic getVariable [QGVAR(controlsUnlocked),false]) && {!isNull (_vic turretUnit [0])}}}) exitWith {
+        if (_set) then {
+            if (currentPilot _vic isEqualTo _unit) then {
+                _unit action ["UnlockVehicleControl", _vic];
+                if (GVAR(pilotUncon) > 1) then {_unit setVariable [QGVAR(unlocked),true]};
+            };
+        };
+    };
+    if ( GVAR(pilotUncon) > 1 && {(_unit getVariable [QGVAR(unlocked),false]) }) then {
+        _unit action ["LockVehicleControl", _vic];
+        _unit setVariable [QGVAR(unlocked),nil]
     };
 };
 

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -483,6 +483,15 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(pilotUncon),
+    "LIST",
+    [LLSTRING(pilotUncon), LLSTRING(pilotUncon_desc)],
+    _category,
+    [[0, 1, 2], [LLSTRING(pilotUncon_0), LLSTRING(pilotUncon_1), LLSTRING(pilotUncon_2)], 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(requestAIforHelp),
     "CHECKBOX",
     [LLSTRING(requestAIforHelp), LLSTRING(requestAIforHelp_desc)],

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -879,6 +879,21 @@
             <English>No speaking at all</English>
             <Polish>Brak możliwości mówienia</Polish>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_pilotUncon">
+            <English>Unlock Pilot Controls when downed</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_pilotUncon_desc">
+            <English>How to handle controls when pilot goes unconscious and has a co-pilot.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_pilotUncon_0">
+            <English>Do not unlock controls</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_pilotUncon_1">
+            <English>Unlock Controls</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_pilotUncon_2">
+            <English>Unlock and Lock when revived</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_requestAIforHelp">
             <English>AI revive squad mates</English>
             <Polish>Leczenie przez AI</Polish>


### PR DESCRIPTION
Adds event accessible with "diw_armor_plates_main_downState", and unlocks controls when a pilot is downed in a copilot enabled vehicle.
Adds playMoveNow call to the switchMove event to prevent downed players doing actions they were doing when downed (self-heal often continued after being downed).