### PR TITLE
Expand regen settings/Add settings for items needed to heal or revive

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -540,6 +540,37 @@ if !(GVAR(aceMedicalLoaded)) then {
             ] call ace_interact_menu_fnc_createAction;
             ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
         };
+
+		private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
+			"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
+			_this spawn {
+				params ["_target", "_player"];
+				private _response = true;
+				if (GVAR(injectorConfirm)) then {
+					_response = [
+						format [LLSTRING(injectorComnfirm_text),(name _target)], // body
+						LLSTRING(giveUp_title), // title
+						localize "str_lib_info_yes", // true return
+						localize "str_lib_info_no", // false return
+						nil, nil, false] call BIS_fnc_guiMessage;
+				};
+				if (!_response) exitWith {};
+				if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
+				private _isProne = stance _player == "PRONE";
+				private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+				private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
+				_medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+				if (_medicAnim != "") then {
+					_player playMove _medicAnim;
+				};
+				[QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
+			};
+		}, {
+			params ["_target", "_player"];
+			alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
+		},{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
+		["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+		["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
     };
 };
 
@@ -571,37 +602,6 @@ if (_aceInteractLoaded) then {
         [_player] call FUNC(canAddPlate)}}
     },{},[], [0,0,0], 3] call ace_interact_menu_fnc_createAction;
     ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action, true] call ace_interact_menu_fnc_addActionToClass;
-
-    private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
-        "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
-        _this spawn {
-            params ["_target", "_player"];
-            private _response = true;
-            if (GVAR(injectorConfirm)) then {
-                _response = [
-                    format [LLSTRING(injectorComnfirm_text),(name _target)], // body
-                    LLSTRING(giveUp_title), // title
-                    localize "str_lib_info_yes", // true return
-                    localize "str_lib_info_no", // false return
-                    nil, nil, false] call BIS_fnc_guiMessage;
-            };
-            if (!_response) exitWith {};
-            if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
-            private _isProne = stance _player == "PRONE";
-            private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-            private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
-            _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-            if (_medicAnim != "") then {
-                _player playMove _medicAnim;
-            };
-            [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
-        };
-    }, {
-        params ["_target", "_player"];
-        alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
-    },{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
-    ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
-    ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
 };
 
 /* Plate transfer events for compatibility use

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -558,18 +558,28 @@ if (_aceInteractLoaded) then {
 
     private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
         "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
-        params ["_target", "_player"];
-        private _isProne = stance _player == "PRONE";
-        private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-        private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
-        _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-        if (_medicAnim != "") then {
-            _player playMove _medicAnim;
-        };
-        [{params ["_target", "_player"];
+        _this spawn {
+            params ["_target", "_player"];
+            private _response = true;
+            if (GVAR(injectorConfirm)) then {
+                _response = [
+                    format [LLSTRING(injectorComnfirm_text),(name _target)], // body
+                    LLSTRING(giveUp_title), // title
+                    localize "str_lib_info_yes", // true return
+                    localize "str_lib_info_no", // false return
+                    nil, nil, false] call BIS_fnc_guiMessage;
+            };
+            if (!_response) exitWith {};
             if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
+            private _isProne = stance _player == "PRONE";
+            private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+            private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
+            _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+            if (_medicAnim != "") then {
+                _player playMove _medicAnim;
+            };
             [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
-        }, _this, 1] call CBA_fnc_waitAndExecute;
+        };
     }, {
         params ["_target", "_player"];
         alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -541,36 +541,36 @@ if !(GVAR(aceMedicalLoaded)) then {
             ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
         };
 
-		private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
-			"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
-			_this spawn {
-				params ["_target", "_player"];
-				private _response = true;
-				if (GVAR(injectorConfirm)) then {
-					_response = [
-						format [LLSTRING(injectorComnfirm_text),(name _target)], // body
-						LLSTRING(giveUp_title), // title
-						localize "str_lib_info_yes", // true return
-						localize "str_lib_info_no", // false return
-						nil, nil, false] call BIS_fnc_guiMessage;
-				};
-				if (!_response) exitWith {};
-				if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
-				private _isProne = stance _player == "PRONE";
-				private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-				private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
-				_medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-				if (_medicAnim != "") then {
-					_player playMove _medicAnim;
-				};
-				[QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
-			};
-		}, {
-			params ["_target", "_player"];
-			alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
-		},{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
-		["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
-		["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+        private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
+            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
+            _this spawn {
+                params ["_target", "_player"];
+                private _response = true;
+                if (GVAR(injectorConfirm)) then {
+                    _response = [
+                        format [LLSTRING(injectorComnfirm_text),(name _target)], // body
+                        LLSTRING(giveUp_title), // title
+                        localize "str_lib_info_yes", // true return
+                        localize "str_lib_info_no", // false return
+                        nil, nil, false] call BIS_fnc_guiMessage;
+                };
+                if (!_response) exitWith {};
+                if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
+                private _isProne = stance _player == "PRONE";
+                private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+                private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
+                _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+                if (_medicAnim != "") then {
+                    _player playMove _medicAnim;
+                };
+                [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
+            };
+        }, {
+            params ["_target", "_player"];
+            alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
+        },{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
+        ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+        ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
     };
 };
 

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -417,8 +417,12 @@ if !(GVAR(aceMedicalLoaded)) then {
                     _args params ["_target", "_caller"];
                     [QGVAR(revive), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
                     if (isNull objectParent _caller) then {
-                        private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+                        private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+                        private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
                         private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+                        private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+                        if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+                        _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
                         _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
                         [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 1)]] call CBA_fnc_globalEvent;
                     };
@@ -428,8 +432,12 @@ if !(GVAR(aceMedicalLoaded)) then {
                     params ["_args"];
                     _args params ["_target", "_caller"];
                     if (isNull objectParent _caller) then {
-                        private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+                        private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+                        private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
                         private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+                        private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+                        if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+                        _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
                         _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
                         [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
                     };
@@ -483,8 +491,12 @@ if !(GVAR(aceMedicalLoaded)) then {
                     params ["_args"];
                     _args params ["_target", "_caller"];
                     if (isNull objectParent _caller) then {
-                        private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+                        private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+                        private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
                         private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+                        private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+                        if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+                        _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
                         _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
                         [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 1)]] call CBA_fnc_globalEvent;
                     };
@@ -494,8 +506,12 @@ if !(GVAR(aceMedicalLoaded)) then {
                     params ["_args"];
                     _args params ["_target", "_caller"];
                     if (isNull objectParent _caller) then {
-                        private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+                        private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+                        private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
                         private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+                        private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+                        if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+                        _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
                         _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
                         [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
                     };

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -152,18 +152,28 @@ _arr3 call BIS_fnc_holdActionAdd;
 
 
 private _id2Array = ["<img image='\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa' size='1.8' shadow=2 />", {
-    params ["", "_caller"];
-    private _isProne = stance _caller == "PRONE";
-    private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-    private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
-    _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-    if (_medicAnim != "") then {
-        _caller playMove _medicAnim;
-    };
-    [{params ["_target", "_caller"];
+    _this spawn {  
+        params ["_target", "_caller"];
+        private _response = true;
+        if (GVAR(injectorConfirm)) then {
+            _response = [
+                format [LLSTRING(injectorComnfirm_text),(name _target)], // body
+                LLSTRING(giveUp_title), // title
+                localize "str_lib_info_yes", // true return
+                localize "str_lib_info_no", // false return
+                nil, nil, false] call BIS_fnc_guiMessage;
+        };
+        if (!_response) exitWith {};
         if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
+        private _isProne = stance _caller == "PRONE";
+        private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+        private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+        _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+        if (_medicAnim != "") then {
+            _caller playMove _medicAnim;
+        };
         [QGVAR(reduceMalus), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
-    }, _this, 1] call CBA_fnc_waitAndExecute;
+    };
 }, [], 9, false, true, "",
 format ["_this getUnitTrait 'Medic' && {alive _originalTarget && {([_this] call %1) && {!(_originalTarget isEqualTo _this && {isNil '%2'})}}}", QFUNC(hasInjector), QGVAR(bleedoutTimeMalus)],
 2.5];

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -94,7 +94,7 @@ _arr2 call BIS_fnc_holdActionAdd;
             [QGVAR(heal), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
         }, _this, 5] call CBA_fnc_waitAndExecute;
     }, [], 10, true, true, "",
-    format ["!(_originalTarget getVariable ['%6',false]) && {alive _originalTarget && { _originalTarget isNotEqualTo _this && {((damage _originalTarget) isEqualTo 0 || %9 isEqualTo 0) && {(_originalTarget getVariable ['%1' , %2]) < (_originalTarget getVariable ['%7', ([%8,%2] select (isPlayer _originalTarget)) * ([%4, %5] select (_this getUnitTrait 'Medic'))]) && {([_this] call %3) >= %9}}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp), QGVAR(healItems)],
+    format ["!(_originalTarget getVariable ['%6',false]) && {alive _originalTarget && { _originalTarget isNotEqualTo _this && {((damage _originalTarget) isEqualTo 0 || {%9 isEqualTo 0}) && {(_originalTarget getVariable ['%1' , %2]) < (_originalTarget getVariable ['%7', ([%8,%2] select (isPlayer _originalTarget)) * ([%4, %5] select (_this getUnitTrait 'Medic'))]) && {([_this] call %3) >= %9}}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp), QGVAR(healItems)],
     3];
     _unit setUserActionText [_id, format [localize "str_a3_cfgactions_healsoldier0", getText ((configOf _unit) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];
 // };

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -45,7 +45,7 @@ private _arr = [_unit, localize "str_heal", "\a3\ui_f\data\IGUI\Cfg\holdactions\
     private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
     private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
-	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
     _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 1)]] call CBA_fnc_globalEvent;
@@ -59,7 +59,7 @@ private _arr = [_unit, localize "str_heal", "\a3\ui_f\data\IGUI\Cfg\holdactions\
     private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
     private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
-	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
     _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
@@ -142,7 +142,7 @@ private _arr3 = [_unit, "Press Wound", "\a3\ui_f\data\IGUI\Cfg\Cursors\unitBleed
     private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
     private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
-	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
     _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 1)]] call CBA_fnc_globalEvent;
@@ -156,7 +156,7 @@ private _arr3 = [_unit, "Press Wound", "\a3\ui_f\data\IGUI\Cfg\Cursors\unitBleed
     private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
     private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
-	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
     _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -41,8 +41,12 @@ private _arr = [_unit, localize "str_heal", "\a3\ui_f\data\IGUI\Cfg\holdactions\
     params ["_target", "_caller"];
     call FUNC(deleteProgressBar);
     [QGVAR(revive), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
-    private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+    private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+    private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+    private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 1)]] call CBA_fnc_globalEvent;
     _target setVariable [QGVAR(beingRevived), nil, true];
@@ -51,8 +55,12 @@ private _arr = [_unit, localize "str_heal", "\a3\ui_f\data\IGUI\Cfg\holdactions\
     // code interrupted
     params ["_target", "_caller"];
     call FUNC(deleteProgressBar);
-    private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+    private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+    private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+    private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
     _target setVariable [QGVAR(beingRevived), nil, true];
@@ -130,8 +138,12 @@ private _arr3 = [_unit, "Press Wound", "\a3\ui_f\data\IGUI\Cfg\Cursors\unitBleed
     // codeCompleted
     params ["_target", "_caller"];
     call FUNC(deleteProgressBar);
-    private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+    private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+    private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+    private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 1)]] call CBA_fnc_globalEvent;
     _target setVariable [QGVAR(isHold), nil, true];
@@ -140,8 +152,12 @@ private _arr3 = [_unit, "Press Wound", "\a3\ui_f\data\IGUI\Cfg\Cursors\unitBleed
     // code interrupted
     params ["_target", "_caller"];
     call FUNC(deleteProgressBar);
-    private _anim = ["amovpknlmstpsloww[wpn]dnon", "amovppnemstpsrasw[wpn]dnon"] select (_caller getVariable [QGVAR(wasProne), false]);
+   private _wasProne = (_caller getVariable [QGVAR(wasProne), false]);
+    private _anim = ["amovpknlmstps[pos]w[wpn]dnon", "amovppnemstps[pos]w[wpn]dnon"] select _wasProne;
     private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+    private _pos = ["non","low","ras","low"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller,"ras"];
+	if (_wasProne && {_pos isEqualTo "low"}) then {_pos = "ras";};
+    _anim = [_anim, "[pos]", _pos] call CBA_fnc_replace;
     _anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
     [QGVAR(switchMove), [_caller, _anim, (GVAR(readyAfterRevive) > 0)]] call CBA_fnc_globalEvent;
     _target setVariable [QGVAR(isHold), nil, true];

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -86,7 +86,7 @@ _arr2 call BIS_fnc_holdActionAdd;
             [QGVAR(heal), [_target, _caller, true], _target] call CBA_fnc_targetEvent;
         }, _this, 5] call CBA_fnc_waitAndExecute;
     }, [], 10, true, true, "",
-    format ["!(_originalTarget getVariable ['%6',false]) && {alive _originalTarget && { _originalTarget isNotEqualTo _this && {(damage _originalTarget) isEqualTo 0 && {(_originalTarget getVariable ['%1' , %2]) < (_originalTarget getVariable ['%7', ([%8,%2] select (isPlayer _originalTarget)) * ([%4, %5] select (_this getUnitTrait 'Medic'))]) && {([_this] call %3) > 0}}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
+    format ["!(_originalTarget getVariable ['%6',false]) && {alive _originalTarget && { _originalTarget isNotEqualTo _this && {((damage _originalTarget) isEqualTo 0 || %9 isEqualTo 0) && {(_originalTarget getVariable ['%1' , %2]) < (_originalTarget getVariable ['%7', ([%8,%2] select (isPlayer _originalTarget)) * ([%4, %5] select (_this getUnitTrait 'Medic'))]) && {([_this] call %3) >= %9}}}}}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp), QGVAR(healItems)],
     3];
     _unit setUserActionText [_id, format [localize "str_a3_cfgactions_healsoldier0", getText ((configOf _unit) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];
 // };

--- a/addons/main/functions/fnc_addActionsToUnit.sqf
+++ b/addons/main/functions/fnc_addActionsToUnit.sqf
@@ -173,7 +173,7 @@ private _id2Array = ["<img image='\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_
         private _response = true;
         if (GVAR(injectorConfirm)) then {
             _response = [
-                format [LLSTRING(injectorComnfirm_text),(name _target)], // body
+                format [LLSTRING(injectorConfirm_text),(name _target)], // body
                 LLSTRING(giveUp_title), // title
                 localize "str_lib_info_yes", // true return
                 localize "str_lib_info_no", // false return

--- a/addons/main/functions/fnc_canRevive.sqf
+++ b/addons/main/functions/fnc_canRevive.sqf
@@ -7,4 +7,4 @@ _target isNotEqualTo _unit && {
 (_target distance _unit) < GVAR(holdActionRange) && {
 !(_unit getVariable ["ace_dragging_isDragging", false]) && {
 !(_unit getVariable ["ace_dragging_isCarrying", false]) && {
-([_unit] call FUNC(hasHealItems)) > 0}}}}}}
+(([_unit] call FUNC(hasHealItems)) >= GVAR(reviveItems))}}}}}}

--- a/addons/main/functions/fnc_handleHealEh.sqf
+++ b/addons/main/functions/fnc_handleHealEh.sqf
@@ -10,7 +10,7 @@
     };
     if ((lifeState _unit) == "INCAPACITATED" || {_unit getVariable [QGVAR(unconscious), false]}) exitWith {};
 
-    if (GVAR(enableHpRegen) && {isPlayer _unit}) exitWith {
+    if (GVAR(enableHpRegen) && {!GVAR(enableHealRegen) && {isPlayer _unit}}) exitWith {
         systemChat LLSTRING(cannotHealWhileRegenOn);
     };
 

--- a/addons/main/functions/fnc_handleHealEh.sqf
+++ b/addons/main/functions/fnc_handleHealEh.sqf
@@ -10,9 +10,10 @@
     };
     if ((lifeState _unit) == "INCAPACITATED" || {_unit getVariable [QGVAR(unconscious), false]}) exitWith {};
 
-    if (GVAR(enableHpRegen) && {!GVAR(enableHealRegen) && {isPlayer _unit}}) exitWith {
+    if (GVAR(enableHpRegen) && {GVAR(enableHealRegen) < 1 && {isPlayer _unit}}) exitWith {
         systemChat LLSTRING(cannotHealWhileRegenOn);
     };
+    if (GVAR(enableHealRegen) > 1) then {[_unit] call FUNC(startHPRegen);};
 
     private _maxHp = _unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)];
     private _curHp = _unit getVariable [QGVAR(hp), _maxHp];

--- a/addons/main/functions/fnc_handleHealEh.sqf
+++ b/addons/main/functions/fnc_handleHealEh.sqf
@@ -13,7 +13,7 @@
     if (GVAR(enableHpRegen) && {GVAR(enableHealRegen) < 1 && {isPlayer _unit}}) exitWith {
         systemChat LLSTRING(cannotHealWhileRegenOn);
     };
-    if (GVAR(enableHealRegen) > 1) then {[_unit] call FUNC(startHPRegen);};
+    if (GVAR(enableHpRegen) && {GVAR(enableHealRegen) > 1}) then {[_unit] call FUNC(startHPRegen);}; // delay regen
 
     private _maxHp = _unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)];
     private _curHp = _unit getVariable [QGVAR(hp), _maxHp];

--- a/addons/main/functions/fnc_hasHealItems.sqf
+++ b/addons/main/functions/fnc_hasHealItems.sqf
@@ -3,6 +3,8 @@ params ["_unit"];
 
 private _items = call FUNC(uniqueItems);
 
+if (GVAR(enableHpRegen) && {!GVAR(enableHealRegen)}) exitWith {-1};
+
 if (_unit getUnitTrait "Medic" && {(GVAR(mediKitItems) arrayIntersect _items) isNotEqualTo []}) exitWith {
     2
 };

--- a/addons/main/functions/fnc_hasHealItems.sqf
+++ b/addons/main/functions/fnc_hasHealItems.sqf
@@ -3,7 +3,7 @@ params ["_unit"];
 
 private _items = call FUNC(uniqueItems);
 
-if (GVAR(enableHpRegen) && {!GVAR(enableHealRegen)}) exitWith {-1};
+if (GVAR(enableHpRegen) && {GVAR(enableHealRegen) < 1}) exitWith {-1};
 
 if (_unit getUnitTrait "Medic" && {(GVAR(mediKitItems) arrayIntersect _items) isNotEqualTo []}) exitWith {
     2

--- a/addons/main/functions/fnc_startHpRegen.sqf
+++ b/addons/main/functions/fnc_startHpRegen.sqf
@@ -7,7 +7,7 @@ if (GVAR(enableHpRegen)) then {
     };
     private _handle = _unit spawn {
         private _unit = _this;
-        sleep 5;
+        sleep GVAR(hpRegenDelay);
 
         // Regenerate HP
         private _maxHp = _unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)];

--- a/addons/main/functions/fnc_startHpRegen.sqf
+++ b/addons/main/functions/fnc_startHpRegen.sqf
@@ -10,10 +10,11 @@ if (GVAR(enableHpRegen)) then {
         sleep GVAR(hpRegenDelay);
 
         // Regenerate HP
-        private _maxHp = (_unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)]) * GVAR(maxHealRegen);
-        while {(_unit getVariable [QGVAR(hp), _maxHp]) < _maxHp && {(lifeState _unit) != "INCAPACITATED"}} do {
+        private _maxHp = _unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)];
+        private _maxRegen = _maxHp * GVAR(maxHealRegen);
+        while {(_unit getVariable [QGVAR(hp), _maxHp]) < _maxRegen && {(lifeState _unit) != "INCAPACITATED"}} do {
             private _newHp = (_unit getVariable [QGVAR(hp), _maxHp]) + (GVAR(hpRegenRate) * 0.1);
-            _unit setVariable [QGVAR(hp), _newHp min _maxHp];
+            _unit setVariable [QGVAR(hp), _newHp min _maxRegen];
             [_unit, _newHp, _maxHp] call FUNC(setA3Damage);
 
             if ((call CBA_fnc_currentUnit) isEqualTo _unit) then {

--- a/addons/main/functions/fnc_startHpRegen.sqf
+++ b/addons/main/functions/fnc_startHpRegen.sqf
@@ -10,7 +10,7 @@ if (GVAR(enableHpRegen)) then {
         sleep GVAR(hpRegenDelay);
 
         // Regenerate HP
-        private _maxHp = _unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)];
+        private _maxHp = (_unit getVariable [QGVAR(maxHP), [GVAR(maxAiHP), GVAR(maxPlayerHP)] select (isPlayer _unit)]) * GVAR(maxHealRegen);
         while {(_unit getVariable [QGVAR(hp), _maxHp]) < _maxHp && {(lifeState _unit) != "INCAPACITATED"}} do {
             private _newHp = (_unit getVariable [QGVAR(hp), _maxHp]) + (GVAR(hpRegenRate) * 0.1);
             _unit setVariable [QGVAR(hp), _newHp min _maxHp];

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -685,10 +685,10 @@ _category = [_header, LLSTRING(subCategoryHealth)];
 
 [
     QGVAR(enableHealRegen),
-    "CHECKBOX",
+    "LIST",
     [LLSTRING(enableHealRegen), LLSTRING(enableHealRegen_desc)],
     _category,
-    false,
+    [[0, 1, 2], [LLSTRING(downedFeedback_0), LLSTRING(enableHealRegen_1), LLSTRING(enableHealRegen_2)], 0],
     true
 ] call CBA_fnc_addSetting;
 
@@ -697,7 +697,16 @@ _category = [_header, LLSTRING(subCategoryHealth)];
     "SLIDER",
     [LLSTRING(hpRegenRate), LLSTRING(hpRegenRate_desc)],
     _category,
-    [1, 100, 10, 2],
+    [0.1, 100, 10, 2],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(hpRegenDelay),
+    "SLIDER",
+    [LLSTRING(hpRegenDelay), LLSTRING(hpRegenDelay_desc)],
+    _category,
+    [0.1, 100, 5, 1],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -684,6 +684,15 @@ _category = [_header, LLSTRING(subCategoryHealth)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(enableHealRegen),
+    "CHECKBOX",
+    [LLSTRING(enableHealRegen), LLSTRING(enableHealRegen_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(hpRegenRate),
     "SLIDER",
     [LLSTRING(hpRegenRate), LLSTRING(hpRegenRate_desc)],

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -602,6 +602,24 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(reviveItems),
+    "LIST",
+    [LLSTRING(reviveItems), LLSTRING(reviveItems_desc)],
+    _category,
+    [[0, 1, 2], [LLSTRING(reviveItems_0), format ["%1 / %2", localize "STR_A3_cfgWeapons_FirstAidKit0", localize "STR_A3_cfgWeapons_Medikit0"], "STR_A3_cfgWeapons_Medikit0"], 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(healItems),
+    "LIST",
+    [LLSTRING(healItems), LLSTRING(healItems_desc)],
+    _category,
+    [[0, 1, 2], [LLSTRING(reviveItems_0), format ["%1 / %2", localize "STR_A3_cfgWeapons_FirstAidKit0", localize "STR_A3_cfgWeapons_Medikit0"], "STR_A3_cfgWeapons_Medikit0"], 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(allowSelfRevive),
     "CHECKBOX",
     [LLSTRING(allowSelfRevive), LLSTRING(allowSelfRevive_desc)],
@@ -707,6 +725,15 @@ _category = [_header, LLSTRING(subCategoryHealth)];
     [LLSTRING(hpRegenDelay), LLSTRING(hpRegenDelay_desc)],
     _category,
     [0.1, 100, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(maxHealRegen),
+    "SLIDER",
+    [LLSTRING(maxHealRegen), LLSTRING(maxHealRegen_desc)],
+    _category,
+    [0, 2, 1, 0, true],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -785,3 +785,12 @@ _category = [_header, LLSTRING(subCategoryHealth)];
         GVAR(injectorCoef) = (parseNumber (_value toFixed 1));
     }
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(injectorConfirm),
+    "CHECKBOX",
+    [LLSTRING(injectorConfirm), LLSTRING(injectorConfirm_desc)],
+    _category,
+    false,
+    false
+] call CBA_fnc_addSetting;

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1138,22 +1138,22 @@
             <Polish>Pozostałych użyć: %1</Polish>
         </Key> -->
         <Key ID="STR_diw_armor_plates_main_useInjector">
-            <English>Use Injector on %1</English>
-            <Polish>Użyj iniektora na %1</Polish>
+            <English>Use auto-injector on %1</English>
+            <Polish>Użyj auto-iniektora na %1</Polish>
         </Key>
         <Key ID="STR_diw_armor_plates_main_useInjectorSelf">
             <English>Self</English>
             <Polish>Sobie</Polish>
         </Key>
         <Key ID="STR_diw_armor_plates_main_useInjectorAce">
-            <English>Use Injector</English>
-            <Polish>Użyj iniektora</Polish>
+            <English>Use auto-injector</English>
+            <Polish>Użyj auto-iniektora</Polish>
         </Key>
         <Key ID="STR_diw_armor_plates_main_injectorComnfirm_text">
-            <English>Use injector on %1?</English>
+            <English>Use auto-injector on %1?</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_injectorComnfirm">
-            <English>Show Injector Confirm dialog</English>
+            <English>Show Auto-Injector Confirm dialog</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_injectorComnfirm_desc">
             <English>Shows a confirmation dialog when using an injector.</English>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1149,5 +1149,14 @@
             <English>Use Injector</English>
             <Polish>Użyj iniektora</Polish>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_injectorComnfirm_text">
+            <English>Use injector on %1?</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_injectorComnfirm">
+            <English>Show Injector Confirm dialog</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_injectorComnfirm_desc">
+            <English>Shows a confirmation dialog when using an injector.</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1156,7 +1156,7 @@
             <English>Show Auto-Injector Confirm dialog</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_injectorConfirm_desc">
-            <English>Shows a confirmation dialog when using an injector.</English>
+            <English>Shows a confirmation dialog when using an auto-injector.</English>
         </Key>
     </Package>
 </Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1149,13 +1149,13 @@
             <English>Use auto-injector</English>
             <Polish>Użyj auto-iniektora</Polish>
         </Key>
-        <Key ID="STR_diw_armor_plates_main_injectorComnfirm_text">
+        <Key ID="STR_diw_armor_plates_main_injectorConfirm_text">
             <English>Use auto-injector on %1?</English>
         </Key>
-        <Key ID="STR_diw_armor_plates_main_injectorComnfirm">
+        <Key ID="STR_diw_armor_plates_main_injectorConfirm">
             <English>Show Auto-Injector Confirm dialog</English>
         </Key>
-        <Key ID="STR_diw_armor_plates_main_injectorComnfirm_desc">
+        <Key ID="STR_diw_armor_plates_main_injectorConfirm_desc">
             <English>Shows a confirmation dialog when using an injector.</English>
         </Key>
     </Package>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -269,6 +269,12 @@
         <Key ID="STR_diw_armor_plates_main_hpRegenDelay_desc">
             <English>How long before hp regen begins?</English>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_maxHealRegen">
+            <English>Max heal % for regen</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_maxHealRegen_desc">
+            <English>What percentage of max health can be regenerated?</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_maxHealMedic">
             <English>Max heal % for medics</English>
             <Polish>Maks. % uleczenia przez medyka</Polish>
@@ -276,7 +282,7 @@
             <Chinese>醫護兵最大治療百分比</Chinese>
         </Key>
         <Key ID="STR_diw_armor_plates_main_maxHealMedic_desc">
-            <English>How percentage of max health can a medic heal?</English>
+            <English>What percentage of max health can a medic heal?</English>
             <Polish>Ile % maksymalnego życia może przywrócić medyk?</Polish>
             <Chinesesimp>医疗兵最大治疗生命值百分比是多少？</Chinesesimp>
             <Chinese>醫療兵最大治療生命值百分比是多少？</Chinese>
@@ -989,6 +995,21 @@
         <Key ID="STR_diw_armor_plates_main_showFAKCountMinimum_desc">
             <English>Only shows the FAK count hint if the remaining FAKs after healing are given number or below</English>
             <Polish>Pokazuje informację o FAKach, jeśli jest w ich ekwipunku tyle lub mniej.</Polish>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_reviveItems">
+            <English>Required Items to Revive</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_reviveItems_desc">
+            <English>Sets what items are need to perform revives.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_reviveItems_0">
+            <English>None Required</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_healItems">
+            <English>Required Items to Heal</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_healItems_desc">
+            <English>Sets what items are need to perform healing.</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_visibleBleedoutTimer">
             <English>Show bleedout timer to</English>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -245,9 +245,6 @@
         <Key ID="STR_diw_armor_plates_main_enableHealRegen_desc">
             <English>How to handle healing with regen enabled.</English>
         </Key>
-        <Key ID="STR_diw_armor_plates_main_enableHealRegen_0">
-            <English>Disable</English>
-        </Key>
         <Key ID="STR_diw_armor_plates_main_enableHealRegen_1">
             <English>Allow</English>
         </Key>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -240,10 +240,19 @@
             <Chinese>允許AI回复HP</Chinese>
         </Key>
         <Key ID="STR_diw_armor_plates_main_enableHealRegen">
-            <English>Enable Heal with regen</English>
+            <English>Healing with Regen on</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_enableHealRegen_desc">
-            <English>Allow healing with regen on</English>
+            <English>How to handle healing with regen enabled.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_enableHealRegen_0">
+            <English>Disable</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_enableHealRegen_1">
+            <English>Allow</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_enableHealRegen_2">
+            <English>Allow and delay regen</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_hpRegenRate">
             <English>HP regen rate</English>
@@ -256,6 +265,12 @@
             <Polish>Szybkość regeneracji życia. Im niższa wartość, tym wolniejsza regeneracja.</Polish>
             <Chinesesimp>HP回复速度；值越低，回复速度越慢。</Chinesesimp>
             <Chinese>HP回复速度；值越低，回复速度越慢。</Chinese>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_hpRegenDelay">
+            <English>HP regen delay</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_hpRegenDelay_desc">
+            <English>How long before hp regen begins?</English>
         </Key>
         <Key ID="STR_diw_armor_plates_main_maxHealMedic">
             <English>Max heal % for medics</English>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -239,6 +239,12 @@
             <Chinesesimp>允许AI回复HP</Chinesesimp>
             <Chinese>允許AI回复HP</Chinese>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_enableHealRegen">
+            <English>Enable Heal with regen</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_enableHealRegen_desc">
+            <English>Allow healing with regen on</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_hpRegenRate">
             <English>HP regen rate</English>
             <Polish>Mnożnik regeneracji HP</Polish>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1129,6 +1129,9 @@
             <English>How many downs Auto-injector cancels on the 'Number of downs' setting.</English>
             <Polish>Jak wiele padnięć anuluje auto-iniektor z ustawienia 'Liczba padnięć'</Polish>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_injectorcomnfirm_text">
+            <English>Auto-injector has been used on %1</English>
+        </Key>
         <!-- <Key ID="STR_diw_armor_plates_main_showUseCount_hint1">
             <English>%1 has been used</English>
             <Polish>Użyto przedmiotu %1</Polish>


### PR DESCRIPTION
Adds settings for handling healing with regen on, regen delay, and the % regen can heal.
Prevents the APS heal action from appearing if disabled with regen on.
Adds settings for items that can be used to heal/revive.
Adds a setting for confirmation of auto-injector use, and removes the one second delay to call the reduceMalus event, and moves the injector ace action into the non-ace med only section.
Fix standing after finishing/canceling hold action, when starting with launcher or no weapon.