### PR TITLE
Add Command Menu/Medical structure actions for APS stuff

### DIFF
--- a/addons/main/CfgEventHandlers.hpp
+++ b/addons/main/CfgEventHandlers.hpp
@@ -15,3 +15,11 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
+
+class Extended_Init_EventHandlers {
+    class Land_MedicalTent_01_base_F {
+        class GVAR(addStructureHeal) {
+            init = QUOTE(_this spawn FUNC(addStructureHeal));
+        };
+    };
+};

--- a/addons/main/CfgEventHandlers.hpp
+++ b/addons/main/CfgEventHandlers.hpp
@@ -15,11 +15,3 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
-
-class Extended_Init_EventHandlers {
-    class Land_MedicalTent_01_base_F {
-        class GVAR(addStructureHeal) {
-            init = QUOTE(_this spawn FUNC(addStructureHeal));
-        };
-    };
-};

--- a/addons/main/CfgVehicles.hpp
+++ b/addons/main/CfgVehicles.hpp
@@ -64,9 +64,9 @@ class CfgVehicles {
     class Camping_base_F;
     class Land_MedicalTent_01_base_F : Camping_base_F {
         class EventHandlers {
-            class CBA_Extended_EventHandlers {
-                init = "call cba_xeh_fnc_init";
-            }
+            class GVAR(medTent) {
+                postInit = QUOTE(_this spawn FUNC(addStructureHeal););
+            };
         };
     };
 };

--- a/addons/main/CfgVehicles.hpp
+++ b/addons/main/CfgVehicles.hpp
@@ -60,4 +60,13 @@ class CfgVehicles {
         function = QFUNC(moduleResetMalusGlobal);
         icon = "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_reviveMedic_ca.paa";
     };
+
+    class Camping_base_F;
+    class Land_MedicalTent_01_base_F : Camping_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers {
+                init = "call cba_xeh_fnc_init";
+            }
+        };
+    };
 };

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -25,6 +25,7 @@ if (GVAR(aceMedicalLoaded)) then {
 } else {
     PREP(addActionsToUnit);
     PREP(addPlayerHoldActions);
+    PREP(addStructureHeal);
     PREP(aiMoveAndHealUnit);
     PREP(canRevive);
     PREP(canHold);

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -28,6 +28,7 @@ if (GVAR(aceMedicalLoaded)) then {
     PREP(aiMoveAndHealUnit);
     PREP(canRevive);
     PREP(canHold);
+    PREP(commandHeal);
     PREP(disableThirdParty);
     PREP(drawDownedUnitIndicator);
     PREP(getHitpointArmor);

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -563,24 +563,21 @@ if !(GVAR(aceMedicalLoaded)) then {
         ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
     };
 
-    if (GVAR(commEnable)) then {
+    [LLSTRING(category), QGVAR(commOpen), LLSTRING(commOpenKeyBind), {
+        if (GVAR(commEnable)) exitWith {false};
+        if (commandingMenu isEqualTo ("#USER:" + QGVAR(commMenu))) exitWith {showCommandingMenu "";};
+        showCommandingMenu ("#USER:" + QGVAR(commMenu));
+        true
+    }, "",
+    [DIK_T, [false, false, true]], false] call CBA_fnc_addKeybind;
 
-        [LLSTRING(category), QGVAR(commOpen), LLSTRING(commOpenKeyBind), {
-            if (commandingMenu isEqualTo ("#USER:" + QGVAR(commMenu))) exitWith {showCommandingMenu "";};
-            showCommandingMenu ("#USER:" + QGVAR(commMenu));
-
-            true
-        }, "",
-        [DIK_T, [false, false, true]], false] call CBA_fnc_addKeybind;
-
-        GVAR(commMenu) = [ [LLSTRING(commMenu),false],
-            ["base",[0],"",-5,[["expression",""]],"0","0"],
-            [LLSTRING(reqHeal),[2],"",-5,[["expression","[player] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","1"],
-            [LLSTRING(reqRevive),[3],"",-5,[["expression","[player] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","1"],
-            [LLSTRING(commandHeal),[4],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"],
-            [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
-        ];
-    };
+    GVAR(commMenu) = [ [LLSTRING(commMenu),false],
+        ["base",[0],"",-5,[["expression",""]],"0","0"],
+        [LLSTRING(reqHeal),[2],"",-5,[["expression","[player] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","1"],
+        [LLSTRING(reqRevive),[3],"",-5,[["expression","[player] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","1"],
+        [LLSTRING(commandHeal),[4],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"],
+        [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
+    ];
 };
 
 // ace interactions

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -541,27 +541,6 @@ if !(GVAR(aceMedicalLoaded)) then {
             ] call ace_interact_menu_fnc_createAction;
             ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
         };
-
-        private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
-            params ["_target", "_player"];
-            private _isProne = stance _player == "PRONE";
-            private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-            private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
-            _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-            if (_medicAnim != "") then {
-                _player playMove _medicAnim;
-            };
-            [{params ["_target", "_player"];
-                if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
-                [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
-            }, _this, 1] call CBA_fnc_waitAndExecute;
-        }, {
-            params ["_target", "_player"];
-            alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
-        },{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
-        ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
-        ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
     };
 
     [LLSTRING(category), QGVAR(commOpen), LLSTRING(commOpenKeyBind), {
@@ -611,6 +590,27 @@ if (_aceInteractLoaded) then {
         [_player] call FUNC(canAddPlate)}}
     },{},[], [0,0,0], 3] call ace_interact_menu_fnc_createAction;
     ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action, true] call ace_interact_menu_fnc_addActionToClass;
+
+	private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
+		"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
+		params ["_target", "_player"];
+		private _isProne = stance _player == "PRONE";
+		private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+		private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
+		_medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+		if (_medicAnim != "") then {
+			_player playMove _medicAnim;
+		};
+		[{params ["_target", "_player"];
+			if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
+			[QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
+		}, _this, 1] call CBA_fnc_waitAndExecute;
+	}, {
+		params ["_target", "_player"];
+		alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
+	},{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
+	["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+	["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
 };
 
 /* Plate transfer events for compatibility use

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -226,7 +226,7 @@ if (GVAR(aceMedicalLoaded)) then {
         };
     }] call CBA_fnc_addEventHandler;
 
-    [QGVAR(resetMalus), {       
+    [QGVAR(resetMalus), {
         if (!alive player) exitWith {};
         GVAR(bleedOutTimeMalus) = nil;
         if (player getVariable [QGVAR(unconscious), false]) then {
@@ -236,7 +236,7 @@ if (GVAR(aceMedicalLoaded)) then {
 
     addMissionEventHandler ["ControlsShifted", {
         params ["", "", "_vehicle", "_copilotEnabled", "_controlsUnlocked"];
-        if (_copilotEnabled) then { 
+        if (_copilotEnabled) then {
             if !(_controlsUnlocked) exitWith {_vehicle setVariable [QGVAR(controlsUnlocked),nil];};
             _vehicle setVariable [QGVAR(controlsUnlocked),true];
         };
@@ -360,7 +360,6 @@ if !(GVAR(aceMedicalLoaded)) then {
     GVAR(firstAidKitItems) = "getNumber (_x >> 'ItemInfo' >> 'type') isEqualTo 401" configClasses (configFile >> "CfgWeapons") apply {configName _x};
     GVAR(mediKitItems) = "getNumber (_x >> 'ItemInfo' >> 'type') isEqualTo 619" configClasses (configFile >> "CfgWeapons") apply {configName _x};
     GVAR(injectorItems) = format ["getNumber (_x >> '%1') > 0", QGVAR(isInjector)] configClasses (configFile >> "CfgWeapons") apply {configName _x};
-    GVAR(medVees) = "getNumber (_x >> 'attendant') > 0" configClasses (configFile >> "CfgVehicles") apply {configName _x};
 
     [] spawn {
         GVAR(playerDamageSync) = player getVariable [QGVAR(maxHP), GVAR(maxPlayerHP)];
@@ -559,7 +558,7 @@ if !(GVAR(aceMedicalLoaded)) then {
         [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
     ];
 
-    {[_x, "init", {_this spawn FUNC(addStructureHeal)}, false, [], true] call CBA_fnc_addClassEventHandler;} forEach GVAR(medVees);
+    {[_x, "init", {_this spawn FUNC(addStructureHeal)}, false, [], true] call CBA_fnc_addClassEventHandler;} forEach ("getNumber (_x >> 'attendant') > 0" configClasses (configFile >> "CfgVehicles") apply {configName _x});
 };
 
 // ace interactions

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -591,26 +591,26 @@ if (_aceInteractLoaded) then {
     },{},[], [0,0,0], 3] call ace_interact_menu_fnc_createAction;
     ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
-	private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
-		"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
-		params ["_target", "_player"];
-		private _isProne = stance _player == "PRONE";
-		private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-		private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
-		_medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-		if (_medicAnim != "") then {
-			_player playMove _medicAnim;
-		};
-		[{params ["_target", "_player"];
-			if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
-			[QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
-		}, _this, 1] call CBA_fnc_waitAndExecute;
-	}, {
-		params ["_target", "_player"];
-		alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
-	},{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
-	["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
-	["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+    private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
+        "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
+        params ["_target", "_player"];
+        private _isProne = stance _player == "PRONE";
+        private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+        private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
+        _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+        if (_medicAnim != "") then {
+            _player playMove _medicAnim;
+        };
+        [{params ["_target", "_player"];
+            if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
+            [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
+        }, _this, 1] call CBA_fnc_waitAndExecute;
+    }, {
+        params ["_target", "_player"];
+        alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
+    },{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
+    ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+    ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
 };
 
 /* Plate transfer events for compatibility use

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -543,34 +543,43 @@ if !(GVAR(aceMedicalLoaded)) then {
 
         private _action2 = [QGVAR(useInjector), LLSTRING(useInjectorAce),
             "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa", {
-            _this spawn {
-                params ["_target", "_player"];
-                private _response = true;
-                if (GVAR(injectorConfirm)) then {
-                    _response = [
-                        format [LLSTRING(injectorComnfirm_text),(name _target)], // body
-                        LLSTRING(giveUp_title), // title
-                        localize "str_lib_info_yes", // true return
-                        localize "str_lib_info_no", // false return
-                        nil, nil, false] call BIS_fnc_guiMessage;
-                };
-                if (!_response) exitWith {};
-                if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
-                private _isProne = stance _player == "PRONE";
-                private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
-                private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
-                _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
-                if (_medicAnim != "") then {
-                    _player playMove _medicAnim;
-                };
-                [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
+            params ["_target", "_player"];
+            private _isProne = stance _player == "PRONE";
+            private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+            private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] find currentWeapon _player, "non"];
+            _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+            if (_medicAnim != "") then {
+                _player playMove _medicAnim;
             };
+            [{params ["_target", "_player"];
+                if (!alive _target || {!alive _player || {_player getVariable [QGVAR(unconscious), false]}}) exitWith {};
+                [QGVAR(reduceMalus), [_target, _player, true], _target] call CBA_fnc_targetEvent;
+            }, _this, 1] call CBA_fnc_waitAndExecute;
         }, {
             params ["_target", "_player"];
             alive _target && {_player getUnitTrait 'Medic' && {(_player call FUNC(hasInjector))}}
         },{},[], [0,0,0], 2.5] call ace_interact_menu_fnc_createAction;
         ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
         ["CAManBase", 0, ["ACE_MainActions"], _action2, true] call ace_interact_menu_fnc_addActionToClass;
+    };
+
+    if (GVAR(commEnable)) then {
+
+        [LLSTRING(category), QGVAR(commOpen), LLSTRING(commOpenKeyBind), {
+            if (commandingMenu isEqualTo ("#USER:" + QGVAR(commMenu))) exitWith {showCommandingMenu "";};
+            showCommandingMenu ("#USER:" + QGVAR(commMenu));
+
+            true
+        }, "",
+        [DIK_T, [false, false, true]], false] call CBA_fnc_addKeybind;
+
+        GVAR(commMenu) = [ [LLSTRING(commMenu),false],
+            ["base",[0],"",-5,[["expression",""]],"0","0"],
+            [LLSTRING(reqHeal),[2],"",-5,[["expression","[player] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","1"],
+            [LLSTRING(reqRevive),[3],"",-5,[["expression","[player] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","1"],
+            [LLSTRING(commandHeal),[4],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"],
+            [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
+        ];
     };
 };
 

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -360,6 +360,7 @@ if !(GVAR(aceMedicalLoaded)) then {
     GVAR(firstAidKitItems) = "getNumber (_x >> 'ItemInfo' >> 'type') isEqualTo 401" configClasses (configFile >> "CfgWeapons") apply {configName _x};
     GVAR(mediKitItems) = "getNumber (_x >> 'ItemInfo' >> 'type') isEqualTo 619" configClasses (configFile >> "CfgWeapons") apply {configName _x};
     GVAR(injectorItems) = format ["getNumber (_x >> '%1') > 0", QGVAR(isInjector)] configClasses (configFile >> "CfgWeapons") apply {configName _x};
+    GVAR(medVees) = "getNumber (_x >> 'attendant') > 0" configClasses (configFile >> "CfgVehicles") apply {configName _x};
 
     [] spawn {
         GVAR(playerDamageSync) = player getVariable [QGVAR(maxHP), GVAR(maxPlayerHP)];
@@ -579,7 +580,7 @@ if !(GVAR(aceMedicalLoaded)) then {
         [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
     ];
 
-	{[_x, "init", {_this spawn FUNC(addStructureHeal)}, true, [], true] call CBA_fnc_addClassEventHandler;} forEach ["B_Slingload_01_Medevac_F","O_Heli_Transport_04_medevac_F","Land_PortableCabinet_01_medical_base_F","Box_UAV_06_medical_base_F"];
+	{[_x, "init", {_this spawn FUNC(addStructureHeal)}, false, [], true] call CBA_fnc_addClassEventHandler;} forEach GVAR(medVees);
 };
 
 // ace interactions

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -580,7 +580,7 @@ if !(GVAR(aceMedicalLoaded)) then {
         [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
     ];
 
-	{[_x, "init", {_this spawn FUNC(addStructureHeal)}, false, [], true] call CBA_fnc_addClassEventHandler;} forEach GVAR(medVees);
+    {[_x, "init", {_this spawn FUNC(addStructureHeal)}, false, [], true] call CBA_fnc_addClassEventHandler;} forEach GVAR(medVees);
 };
 
 // ace interactions

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -564,7 +564,7 @@ if !(GVAR(aceMedicalLoaded)) then {
     };
 
     [LLSTRING(category), QGVAR(commOpen), LLSTRING(commOpenKeyBind), {
-        if (GVAR(commEnable)) exitWith {false};
+        if (!GVAR(commEnable)) exitWith {false};
         if (commandingMenu isEqualTo ("#USER:" + QGVAR(commMenu))) exitWith {showCommandingMenu "";};
         showCommandingMenu ("#USER:" + QGVAR(commMenu));
         true
@@ -578,6 +578,8 @@ if !(GVAR(aceMedicalLoaded)) then {
         [LLSTRING(commandHeal),[4],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"],
         [LLSTRING(commandRevive),[5],"",-5,[["expression","[cursorTarget] call diw_armor_plates_main_fnc_commandHeal;"]],"!isAlone","CursorOnFriendly"]
     ];
+
+	{[_x, "init", {_this spawn FUNC(addStructureHeal)}, true, [], true] call CBA_fnc_addClassEventHandler;} forEach ["B_Slingload_01_Medevac_F","O_Heli_Transport_04_medevac_F","Land_PortableCabinet_01_medical_base_F","Box_UAV_06_medical_base_F"];
 };
 
 // ace interactions

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 params["_structure"];
 
-if (_structure isKindOf "CAManBase") exitWith {};
+if (!GVAR(healAtMedic) && {_structure isKindOf "CAManBase"}) exitWith {};
 
 private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />", {
         params ["", "_caller"];

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -13,10 +13,13 @@ private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\
         [{
             params ["_target", "_caller"];
             if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
-            private _isMedic = _caller getUnitTrait "Medic";
-            if (!_isMedic) then {_caller setUnitTrait ["Medic", true]};
+            if !(_caller getUnitTrait "Medic") then {
+                _caller setUnitTrait ["Medic", true]
+                [{  params ["_caller"];
+                    _caller setUnitTrait ["Medic", false]; 
+                }, [_caller], 1] call CBA_fnc_waitAndExecute;
+            };
             [QGVAR(heal), [_caller, _caller, false], _caller] call CBA_fnc_targetEvent;
-            [{params ["_caller","_isMedic"];if (!_isMedic) then {_caller setUnitTrait ["Medic", false]}; }, [_caller,_isMedic], 1] call CBA_fnc_waitAndExecute;
         }, _this, 5] call CBA_fnc_waitAndExecute;
     }, [], 10, true, true, "",
     format ["!(_this getVariable ['%6',false]) && {alive _this && {(_this getVariable ['%1' , %2]) < (_this getVariable ['%7', ([%8,%2] select (isPlayer _this)) * %5]) }}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -18,12 +18,13 @@ private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\
             if !(_caller getUnitTrait "Medic") then {
                 _caller setUnitTrait ["Medic", true];
                 [{  params ["_caller"];
-                    _caller setUnitTrait ["Medic", false]; 
+                    _caller setUnitTrait ["Medic", false];
                 }, [_caller], 1] call CBA_fnc_waitAndExecute;
             };
             [QGVAR(heal), [_caller, _caller, false], _caller] call CBA_fnc_targetEvent;
         }, _this, 5] call CBA_fnc_waitAndExecute;
     }, [], 10, true, true, "",
-    format ["!(_this getVariable ['%6',false]) && {alive _this && {(_this getVariable ['%1' , %2]) < (_this getVariable ['%7', ([%8,%2] select (isPlayer _this)) * %5]) }}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
+    format ["!(_this getVariable ['%5',false]) && {alive _this && {(_this getVariable ['%1' , %2]) < (_this getVariable ['%6', ([%7,%2] select (isPlayer _this)) * %4]) }}", QGVAR(hp), QGVAR(maxPlayerHP), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
+    // format ["!(_this getVariable ['%6',false]) && {alive _this && {(_this getVariable ['%1' , %2]) < (_this getVariable ['%7', ([%8,%2] select (isPlayer _this)) * %5]) }}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
     ((sizeOf (typeOf _structure)) min 9)];
     _structure setUserActionText [_id, format [((localize "STR_A3_CfgActions_Heal0") + " (APS)"), getText ((configOf _structure) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -14,7 +14,7 @@ private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\
             params ["_target", "_caller"];
             if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
             if !(_caller getUnitTrait "Medic") then {
-                _caller setUnitTrait ["Medic", true]
+                _caller setUnitTrait ["Medic", true];
                 [{  params ["_caller"];
                     _caller setUnitTrait ["Medic", false]; 
                 }, [_caller], 1] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 params["_structure"];
 
+if (_structure isKindOf "CAManBase") exitWith {};
+
 private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />", {
         params ["", "_caller"];
         private _isProne = stance _caller == "PRONE";

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+params["_structure"];
+
+private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />", {
+        params ["", "_caller"];
+        private _isProne = stance _caller == "PRONE";
+        private _medicAnim = ["AinvPknlMstpSlayW[wpn]Dnon_medicOther", "AinvPpneMstpSlayW[wpn]Dnon_medicOther"] select _isProne;
+        private _wpn = ["non", "rfl", "lnr", "pst"] param [["", primaryWeapon _caller, secondaryWeapon _caller, handgunWeapon _caller] find currentWeapon _caller, "non"];
+        _medicAnim = [_medicAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+        if (_medicAnim != "") then {
+            _caller playMove _medicAnim;
+        };
+        [{
+            params ["_target", "_caller"];
+            if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
+			private _isMedic = _caller getUnitTrait "Medic";
+			if (!_isMedic) then {_caller setUnitTrait ["Medic", true]};
+            [QGVAR(heal), [_caller, _caller, false], _caller] call CBA_fnc_targetEvent;
+			[{params ["_caller","_isMedic"];if (!_isMedic) then {_caller setUnitTrait ["Medic", false]}; }, [_caller,_isMedic], 1] call CBA_fnc_waitAndExecute;
+        }, _this, 5] call CBA_fnc_waitAndExecute;
+    }, [], 10, true, true, "",
+    format ["!(_this getVariable ['%6',false]) && {alive _this && {(_this getVariable ['%1' , %2]) < (_this getVariable ['%7', ([%8,%2] select (isPlayer _this)) * %5]) }}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
+    10];
+    _structure setUserActionText [_id, format [((localize "STR_A3_CfgActions_Heal0") + " (APS)"), getText ((configOf _structure) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];

--- a/addons/main/functions/fnc_addStructureHeal.sqf
+++ b/addons/main/functions/fnc_addStructureHeal.sqf
@@ -13,12 +13,12 @@ private _id = _structure addAction ["<img image='\A3\ui_f\data\igui\cfg\actions\
         [{
             params ["_target", "_caller"];
             if (!alive _target || {!alive _caller || {_caller getVariable [QGVAR(unconscious), false]}}) exitWith {};
-			private _isMedic = _caller getUnitTrait "Medic";
-			if (!_isMedic) then {_caller setUnitTrait ["Medic", true]};
+            private _isMedic = _caller getUnitTrait "Medic";
+            if (!_isMedic) then {_caller setUnitTrait ["Medic", true]};
             [QGVAR(heal), [_caller, _caller, false], _caller] call CBA_fnc_targetEvent;
-			[{params ["_caller","_isMedic"];if (!_isMedic) then {_caller setUnitTrait ["Medic", false]}; }, [_caller,_isMedic], 1] call CBA_fnc_waitAndExecute;
+            [{params ["_caller","_isMedic"];if (!_isMedic) then {_caller setUnitTrait ["Medic", false]}; }, [_caller,_isMedic], 1] call CBA_fnc_waitAndExecute;
         }, _this, 5] call CBA_fnc_waitAndExecute;
     }, [], 10, true, true, "",
     format ["!(_this getVariable ['%6',false]) && {alive _this && {(_this getVariable ['%1' , %2]) < (_this getVariable ['%7', ([%8,%2] select (isPlayer _this)) * %5]) }}", QGVAR(hp), QGVAR(maxPlayerHP), QFUNC(hasHealItems), QGVAR(maxHealRifleman), QGVAR(maxHealMedic), QGVAR(unconscious), QGVAR(maxHp), QGVAR(maxAiHp)],
-    10];
+    ((sizeOf (typeOf _structure)) min 9)];
     _structure setUserActionText [_id, format [((localize "STR_A3_CfgActions_Heal0") + " (APS)"), getText ((configOf _structure) >> "displayName")], "<img image='\A3\ui_f\data\igui\cfg\actions\heal_ca.paa' size='1.8' shadow=2 />"];

--- a/addons/main/functions/fnc_commandHeal.sqf
+++ b/addons/main/functions/fnc_commandHeal.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+params ["_target"];
+
+private _group = (units group player);
+private _med = _group findIf {_x isNotEqualTo _target && {
+    alive _x && {
+    !(_x getVariable [QGVAR(hasHealRequest), false]) && {
+    !isPlayer _x && {
+    (lifeState _x) != 'INCAPACITATED' && {
+    _x getUnitTrait 'Medic' && {
+    simulationEnabled _x && {
+    _x checkAIFeature 'PATH' && {
+    ([_x] call FUNC(hasHealItems)) > 0}}}}}}}}};
+if (_med < 0) then {
+    _med = _group findIf {_x isNotEqualTo _target && {
+        alive _x && {
+        !(_x getVariable [QGVAR(hasHealRequest), false]) && {
+        !isPlayer _x && {
+        (lifeState _x) != 'INCAPACITATED' && {
+        simulationEnabled _x && {
+        _x checkAIFeature 'PATH' && {
+        ([_x] call FUNC(hasHealItems)) > 0}}}}}}}};
+};
+if (_med > -1) then {[_target, (_group select _med)] spawn diw_armor_plates_main_fnc_aiMoveAndHealUnit;
+} else { systemChat LLSTRING(noMedic); };

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -501,6 +501,15 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(commEnable),
+    "CHECKBOX",
+    [LLSTRING(commEnable), LLSTRING(commEnable_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(bleedoutTime),
     "SLIDER",
     [LLSTRING(bleedoutTime), LLSTRING(bleedoutTime_desc)],

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -506,6 +506,8 @@ _category = [_header, LLSTRING(subCategoryGeneral)];
     [LLSTRING(commEnable), LLSTRING(commEnable_desc)],
     _category,
     false,
+    true,
+    {},
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -767,6 +767,17 @@ _category = [_header, LLSTRING(subCategoryHealth)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(healAtMedic),
+    "CHECKBOX",
+    [LLSTRING(healAtMedic), LLSTRING(healAtMedic_desc)],
+    _category,
+    false,
+    true,
+    {},
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(allowLimping),
     "CHECKBOX",
     [LLSTRING(allowLimping), LLSTRING(allowLimping_desc)],

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -924,6 +924,33 @@
             <Chinesesimp>AI复活队友</Chinesesimp>
             <Chinese>AI復活隊友</Chinese>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_commEnable">
+            <English>Enable AI commands</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_commEnable_desc">
+            <English>Enables the ability to command Medic AI to heal/revive through the Command menu (access with new keybind).</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_noMedic">
+            <English>No medic available.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_reqHeal">
+            <English>Request Heal</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_reqRevive">
+            <English>Request Revive</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_commandHeal">
+            <English>Heal target</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_commandRevive">
+            <English>Revive target</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_commMenu">
+            <English>APS Commands</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_commOpenKeyBind">
+            <English>APS Commands Menu</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_requestAIforHelp_desc">
             <English>Enables the abillity for AI to revive unconscious squad mates</English>
             <Polish>Dodaje botom możliwość leczenia nieprzytomnych sojuszników.</Polish>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -299,6 +299,12 @@
             <Chinesesimp>非医疗兵最大治疗生命值百分比是多少？</Chinesesimp>
             <Chinese>非醫療兵最大治療生命值百分比是多少？</Chinese>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_healAtMedic">
+            <English>Allow Players to Heal at Medics</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_healAtMedic_desc">
+            <English>Players will have an addAction on units classed as medics to heal to the percentage medics give.</English>
+        </Key>
         <Key ID="STR_diw_armor_plates_main_subCategoryGeneral">
             <English>General</English>
             <Polish>Ogólne</Polish>


### PR DESCRIPTION
Adds a command menu accessible through a new keybind, allowing players to give orders to medics in their team.
Adds addActions to medical structures/vehicles to full heal APS health. (Tents weren't xeh so did them through config)