### PR TITLE
ACE damage handler update for compatibility with ACE3 3.16.0

### DIFF
--- a/addons/main/functions/fnc_aceDamageHandler.sqf
+++ b/addons/main/functions/fnc_aceDamageHandler.sqf
@@ -22,7 +22,7 @@ if ((_copy select 0 select 0) > 0) then {
         _aceSelection = "Hitchest";
     };
 
-    private _bodyArmor = ([vest _unit, _aceSelection] call ace_medical_engine_fnc_getItemArmor) + ([uniform _unit, _aceSelection] call ace_medical_engine_fnc_getItemArmor);
+    private _bodyArmor = ([vest _unit, _aceSelection] call ace_medical_engine_fnc_getItemArmor select 1) + ([uniform _unit, _aceSelection] call ace_medical_engine_fnc_getItemArmor select 1);
 
     private _actualDamage = _damage;
     if (_bodyArmor > 0 && {_hitPointArmor > 0}) then {


### PR DESCRIPTION
ACE3 version 3.16.0 returns an array of armor values instead of a single value; I opted to use ace3's new "adjusted armor value" based on armor's passthrough config value rather than just the base armor.