### PR TITLE
Fix no healing animations

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -83,7 +83,7 @@ if (GVAR(aceMedicalLoaded)) then {
                 _unit setDamage 0;
                 [_unit, _healer, true] call FUNC(handleHealEh);
             }, _this, 5] call CBA_fnc_waitAndExecute;
-            true
+            false
         }];
 
         [_unit] call FUNC(addActionsToUnit);


### PR DESCRIPTION
Issue happened as the previously used CBA XEH did not really return the values to the event handler as per internal CBA logic. Now it does, thus the engine thinks APS will handle everything, tho we just wait for a bit, and then heal, while the engine takes over the healing animation.