### PR TITLE
Add Plate Toughness inspired by Darktide

### DIFF
--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -17,6 +17,7 @@ PREP(showDamageFeedbackMarker);
 PREP(uniqueItems);
 PREP(updateHPUi);
 PREP(updatePlateUi);
+PREP(toughLoop);
 
 if (GVAR(aceMedicalLoaded)) then {
     PREP(aceDamageHandler);

--- a/addons/main/functions/fnc_handleArmorDamage.sqf
+++ b/addons/main/functions/fnc_handleArmorDamage.sqf
@@ -4,6 +4,11 @@ params ["_unit", "_damage", "_isTorso", "_player", "_ammo", "_instigator"];
 private _receivedDamage = false;
 private _vest = vestContainer _unit;
 private _plates = _vest getVariable [QGVAR(plates), []];
+
+if (_player isEqualTo _unit) then {
+    _unit setVariable [QGVAR(hitTime), cba_missionTime];
+};
+
 if (_plates isEqualTo [] || {!_isTorso && {GVAR(protectOnlyTorso)}}) exitWith {[_damage, _receivedDamage]};
 
 switch (GVAR(armorHandlingMode)) do {
@@ -35,6 +40,9 @@ switch (GVAR(armorHandlingMode)) do {
                 [_unit, _instigator, _damage] call FUNC(showDamageFeedbackMarker);
             };
             _receivedDamage = true;
+            if (GVAR(plateToughness)) then {
+                [cba_missionTime] call FUNC(toughLoop);
+            };
         };
     };
     case "realism": {
@@ -81,6 +89,9 @@ switch (GVAR(armorHandlingMode)) do {
             [_unit] call FUNC(updatePlateUi);
             if (GVAR(showDamageMarker)) then {
                 [_unit, _instigator, _damage] call FUNC(showDamageFeedbackMarker);
+            };
+            if (GVAR(plateToughness)) then {
+                [cba_missionTime] call FUNC(toughLoop);
             };
         };
     };

--- a/addons/main/functions/fnc_handleArmorDamage.sqf
+++ b/addons/main/functions/fnc_handleArmorDamage.sqf
@@ -4,12 +4,11 @@ params ["_unit", "_damage", "_isTorso", "_player", "_ammo", "_instigator"];
 private _receivedDamage = false;
 private _vest = vestContainer _unit;
 private _plates = _vest getVariable [QGVAR(plates), []];
+if (_plates isEqualTo [] || {!_isTorso && {GVAR(protectOnlyTorso)}}) exitWith {[_damage, _receivedDamage]};
 
-if (_player isEqualTo _unit) then {
+if (GVAR(plateToughness) && {_player isEqualTo _unit}) then {
     _unit setVariable [QGVAR(hitTime), cba_missionTime];
 };
-
-if (_plates isEqualTo [] || {!_isTorso && {GVAR(protectOnlyTorso)}}) exitWith {[_damage, _receivedDamage]};
 
 switch (GVAR(armorHandlingMode)) do {
     case "arcade": {
@@ -41,7 +40,7 @@ switch (GVAR(armorHandlingMode)) do {
             };
             _receivedDamage = true;
             if (GVAR(plateToughness)) then {
-                [cba_missionTime] call FUNC(toughLoop);
+                [cba_missionTime] spawn FUNC(toughLoop);
             };
         };
     };
@@ -91,7 +90,7 @@ switch (GVAR(armorHandlingMode)) do {
                 [_unit, _instigator, _damage] call FUNC(showDamageFeedbackMarker);
             };
             if (GVAR(plateToughness)) then {
-                [cba_missionTime] call FUNC(toughLoop);
+                [cba_missionTime] spawn FUNC(toughLoop);
             };
         };
     };

--- a/addons/main/functions/fnc_toughLoop.sqf
+++ b/addons/main/functions/fnc_toughLoop.sqf
@@ -1,0 +1,57 @@
+#include "../script_component.hpp"
+
+params ["_hitCheck",['_skip',false]];
+
+private _delay = GVAR(plateDelay);
+if (!_skip) then {sleep _delay;};
+if (_hitCheck isNotEqualTo (player getVariable [QGVAR(hitTime), 0])) exitWith {};
+private _full = true;
+private _plateCarrier = (vestContainer player);
+if (!alive player || {_plateCarrier isEqualTo objNull}) exitWith {};
+private _plates = _plateCarrier getVariable [QGVAR(plates), [0]];
+private _plateCnt = count _plates;
+private _plateRegenCount = (GVAR(plateRegenCount) - 1) min (GVAR(numWearablePlates) - 1);
+
+if (_plateCnt > _plateRegenCount) exitWith {player setVariable [QGVAR(hitTime), nil]};
+
+for '_i' from _plateCnt to _plateRegenCount do {
+    _plates pushBack 0;
+};
+
+private _plateMaxHp = GVAR(maxPlateHealth);
+_plateCnt = _plates findIf {_x < _plateMaxHp};
+_plateCarrier setVariable [QGVAR(plates), _plates];
+private _tickRegen = GVAR(plateRegenPerTick);
+private _waitTime = (GVAR(plateRegenSpeed)/_plateMaxHp) * _tickRegen;
+private _inter = GVAR(plateDelayInter);
+
+while {_plateCnt isNotEqualTo -1} do {
+    private _skip = false;
+    private _toughPlate = _plates # _plateCnt;
+    while {alive player} do {
+        sleep _waitTime;
+        if (_hitCheck isNotEqualTo (player getVariable [QGVAR(hitTime), 0])) exitWith {_full = false; break};
+        _plates = (_plateCarrier getVariable [QGVAR(plates), [0]]);
+        private _plateChk = _plates # _plateCnt;
+        if (_plateChk > _toughPlate) exitWith {_skip = true};
+        _toughPlate = _toughPlate + _tickRegen;
+        _plates set [_plateCnt, (_toughPlate min _plateMaxHp)];
+        _plateCarrier setVariable [QGVAR(plates), _plates];
+        [player] call FUNC(updatePlateUi);
+        if (_toughPlate >= _plateMaxHp) then {break};
+    };
+    if (_inter && {!_skip}) then {
+        sleep _delay;
+        if (_hitCheck isNotEqualTo (player getVariable [QGVAR(hitTime), 0])) exitWith {_full = false; break};
+        _plates = _plateCarrier getVariable [QGVAR(plates), []];
+        private _plateChk = _plates # _plateCnt;
+        if (isNil "_plateChk") exitWith {  };
+        if (_plateChk > _toughPlate) exitWith {_skip = true};
+        _plateCnt = (count _plates - 1) max 0;
+        for '_i' from _plateCnt to (_plateRegenCount - 1) do {
+            _plates pushBack 0;
+        };
+    };
+    _plateCnt = _plates findIf {_x < _plateMaxHp};
+};
+if (_full) then {player setVariable [QGVAR(hitTime), nil]};

--- a/addons/main/initSettings.inc.sqf
+++ b/addons/main/initSettings.inc.sqf
@@ -167,6 +167,60 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     true
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(plateToughness),
+    "CHECKBOX",
+    [LLSTRING(plateToughness), LLSTRING(plateToughness_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateRegenCount),
+    "SLIDER",
+    [LLSTRING(plateRegenCount), LLSTRING(plateRegenCount_desc)],
+    _category,
+    [1, 10, 1, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateDelay),
+    "SLIDER",
+    [LLSTRING(plateDelay), LLSTRING(plateDelay_desc)],
+    _category,
+    [1, 600, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateDelayInter),
+    "CHECKBOX",
+    [LLSTRING(plateDelayInter), LLSTRING(plateDelayInter_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateRegenSpeed),
+    "SLIDER",
+    [LLSTRING(plateRegenSpeed), LLSTRING(plateRegenSpeed_desc)],
+    _category,
+    [1, 600, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateRegenPerTick),
+    "SLIDER",
+    [LLSTRING(plateRegenPerTick), LLSTRING(plateRegenPerTick_desc)],
+    _category,
+    [0.5, 100, 0.5, 1],
+    false
+] call CBA_fnc_addSetting;
+
 _category = [_header, LLSTRING(subCategoryFeedback)];
 
 [

--- a/addons/main/initSettingsACE.inc.sqf
+++ b/addons/main/initSettingsACE.inc.sqf
@@ -180,6 +180,60 @@ private _category = [_header, LLSTRING(subCategoryArmorPlates)];
     }
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(plateToughness),
+    "CHECKBOX",
+    [LLSTRING(plateToughness), LLSTRING(plateToughness_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateRegenCount),
+    "SLIDER",
+    [LLSTRING(plateRegenCount), LLSTRING(plateRegenCount_desc)],
+    _category,
+    [1, 10, 1, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateDelay),
+    "SLIDER",
+    [LLSTRING(plateDelay), LLSTRING(plateDelay_desc)],
+    _category,
+    [1, 600, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateDelayInter),
+    "CHECKBOX",
+    [LLSTRING(plateDelayInter), LLSTRING(plateDelayInter_desc)],
+    _category,
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateRegenSpeed),
+    "SLIDER",
+    [LLSTRING(plateRegenSpeed), LLSTRING(plateRegenSpeed_desc)],
+    _category,
+    [1, 600, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(plateRegenPerTick),
+    "SLIDER",
+    [LLSTRING(plateRegenPerTick), LLSTRING(plateRegenPerTick_desc)],
+    _category,
+    [0.5, 100, 0.5, 1],
+    false
+] call CBA_fnc_addSetting;
+
 _category = [_header, LLSTRING(subCategoryFeedback)];
 
 [

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1779,5 +1779,41 @@
             <Chinesesimp>兼容性</Chinesesimp>
             <Polish>Kompatybilność</Polish>
         </Key>
+        <Key ID="STR_diw_armor_plates_main_plateToughness">
+            <English>Enable Plate Toughness</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateToughness_desc">
+            <English>Players can regen plates over time, starts after delay while not taking damage.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateRegenCount">
+            <English>Number of Tough Plates</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateRegenCount_desc">
+            <English>How many plates are affected by the toughness regen. Limited by plates wearable setting in Armor Plates System.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateDelay">
+            <English>Plate Toughness Delay</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateDelay_desc">
+            <English>Number of seconds after damage is taken before toughness starts to regen armor plates.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateDelayInter">
+            <English>Delay between plates</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateDelayInter_desc">
+            <English>Whether to apply delay between each full plate during regeneration.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateRegenSpeed">
+            <English>Toughness Regen Speed</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateRegenSpeed_desc">
+            <English>Time in seconds it takes to regenerate a single plate to full armor.</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateRegenPerTick">
+            <English>Plate Armor per Tick</English>
+        </Key>
+        <Key ID="STR_diw_armor_plates_main_plateRegenPerTick_desc">
+            <English>Minimum regen to apply, affects tick speed but not the seconds to full plate. Will not regen more than one full plate per tick.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Adds system allowing players to regenerate plates similar to Darktide's Toughness or energy shields in other games. Plate items can still be consumed as a faster replenishment.